### PR TITLE
Fix contenteditable FF bug inserting br tags

### DIFF
--- a/src/tagify.js
+++ b/src/tagify.js
@@ -125,7 +125,7 @@ Tagify.prototype = {
         var that = this,
             DOM  = this.DOM,
             template = `<tags class="tagify ${this.settings.mode ? "tagify--mix" : "" } ${input.className}" ${this.settings.readonly ? 'readonly' : ''}>
-                            <div contenteditable data-placeholder="${input.placeholder || '&#8203;'}" class="tagify__input"></div>
+                            <span contenteditable data-placeholder="${input.placeholder || '&#8203;'}" class="tagify__input"></span>
                         </tags>`;
 
         DOM.originalInput = input;

--- a/src/tagify.scss
+++ b/src/tagify.scss
@@ -235,6 +235,7 @@
 
         margin: $tagMargin;
         padding: $tagPad;
+        display: block;
         position: relative;
 
         &:empty::before{ @include placeholder; }


### PR DESCRIPTION
Starting with no tags in Firefox, and then inserting and removing there will be an alternating sequence where the first letter automatically turns into a tag due to the fact Firefox will insert a br tag which turns into a \n and then converted over to the delimiter (a comma) which causes tagify to think it is supposed to be a tag.

Easily duplicated on your demo in Firefox. Start by entering aaa, then backspacing removing them all. Then enter aaa again and backspace removing everything. Due to the fact that a BR tag is left behind for contenteditable div tags, every other time the first a keystroke will be turned into a tag before the user was finished typing their tag.

This is solved for firefox by turning the div into a span and making sure the span has a display of block. Thus no BR tag is left behind then. Alternatively, and maybe a better approach would be to make sure that input normalize function completely removes newlines at the beginning of a string instead of turning it into a delimiter (a comma with default settings).

https://stackoverflow.com/questions/38770279/javascript-contenteditable-prevent-br-when-there-is-no-text
https://bugzilla.mozilla.org/show_bug.cgi?id=1249374