### PR TITLE
Fix exception when input initial value is an empty json list

### DIFF
--- a/src/tagify.js
+++ b/src/tagify.js
@@ -862,7 +862,7 @@ Tagify.prototype = {
 
         if( !tagsItems || !tagsItems.length ){
             console.warn('[addTags]', 'no tags to add:', tagsItems)
-            return;
+            return tagElems;
         }
 
         tagsItems = this.normalizeTags.call(this, tagsItems);


### PR DESCRIPTION
When an input field with a value `[]` is initialized with `Tagify(elem, {})`
the `addTags()` function did not return a list. This lead to this error:

```
18:22:13.619 [addTags] no tags to add: Array [] tagify.min.js:10:14147
18:22:13.661 TypeError: this.addTags(...) is undefined[Learn More] main_min-2019.03.19.js line 108 > eval:10:2646
```