### PR TITLE
Cleanup annoying "[addTags] no tags to add: Array []" console warning

### DIFF
--- a/src/tagify.js
+++ b/src/tagify.js
@@ -940,7 +940,6 @@ Tagify.prototype = {
         var tagElems = [];
 
         if( !tagsItems || !tagsItems.length ){
-            console.warn('[addTags]', 'no tags to add:', tagsItems)
             return tagElems;
         }
 


### PR DESCRIPTION
When initializing Tagify() on an existing input element that has an
empty json list "[]" as value, the warning is printed on the console.

An empty list is a normal use case when initializing an empty label
input. For this reason there should be no warning triggered in this
situation.