### PR TITLE
Remove "hasMaxTags" class when limit is not reached anymore

### DIFF
--- a/src/tagify.js
+++ b/src/tagify.js
@@ -1068,6 +1068,7 @@ Tagify.prototype = {
         if( !silent ){
             tagData = this.value.splice(tagIdx, 1)[0]; // remove the tag from the data object
             this.update() // update the original input with the current value
+            this.DOM.scope.classList.toggle('hasMaxTags',  this.value.length >= this.settings.maxTags);
             this.trigger('remove', { tag:tagElm, index:tagIdx, data:tagData });
             this.dropdown.render.call(this);
         }


### PR DESCRIPTION
Once the maxTags tags are reached, the hasMaxTags class is added to the
tagify node. This commit enables tagify to remove the hasMaxTags class
once the number of tags is below the limit when a tag has been removed.