### PR TITLE
fix: this.settings is undefined in function-scope

### DIFF
--- a/src/tagify.js
+++ b/src/tagify.js
@@ -1180,7 +1180,7 @@ Tagify.prototype = {
                 that.dropdown.render.call(that);
                 that.dropdown.position.call(that)
             }
-            else if( this.settings.keepInvalidTags )
+            else if( that.settings.keepInvalidTags )
                 that.trigger('remove', { tag:tagElm, index:tagIdx })
         }
 


### PR DESCRIPTION
When having duplications in the tag-list, the non-silent removeNode()-method used an undefined this.settings instead of that.settings.

Solves: Cannot read property 'keepInvalidTags' of undefined