### PR TITLE
Added new dropdown event called dropdown:rendered

### DIFF
--- a/dist/tagify.js
+++ b/dist/tagify.js
@@ -1645,6 +1645,7 @@ Tagify.prototype = {
           this.DOM.dropdown.classList.add('tagify__dropdown--initial');
           this.dropdown.position.call(this, ddHeight);
           document.body.appendChild(this.DOM.dropdown);
+		  this.trigger("dropdown:rendered", this.DOM.dropdown);
           setTimeout(function () {
             return _this12.DOM.dropdown.classList.remove('tagify__dropdown--initial');
           });


### PR DESCRIPTION
Added new drop down _event_ called **dropdown:rendered**. This is useful, if users wish to add **perfect-scrollbar.js** to the drop down select box. 

https://github.com/mdbootstrap/perfect-scrollbar

Using **dropdown:show** will not work, because the drop down has not been appended to the DOM, at this point. And using:

setTimeout()

With **dropdown:show**, is unreliable, because it is difficult to predict, how long it will take for the drop down to be appended to the DOM, taking into account different network bandwidths.

This _event_ could also be useful for when a developer wishes to manipulate the drop down select box, in any way or attach another JavaScript plugin to it.