### PR TITLE
add event on invalid input when in edit mode

### DIFF
--- a/src/tagify.js
+++ b/src/tagify.js
@@ -157,7 +157,7 @@ Tagify.prototype = {
         }
     },
 
-    customEventsList : ['add', 'remove', 'invalid', 'input', 'click', 'keydown', 'focus', 'blur', 'edit:input', 'edit:updated', 'edit:start', 'edit:keydown', 'dropdown:show', 'dropdown:hide', 'dropdown:select'],
+    customEventsList : ['add', 'remove', 'invalid', 'input', 'click', 'keydown', 'focus', 'blur', 'edit:input', 'edit:updated', 'edit:start', 'edit:keydown', 'edit:invalid', 'dropdown:show', 'dropdown:hide', 'dropdown:select'],
 
     applySettings( input, settings ){
         this.DEFAULTS.templates = this.templates;
@@ -821,18 +821,28 @@ Tagify.prototype = {
                     return
                 }
 
-                if( hasChanged ){
+                let invalidCause = null;
+                if( hasChanged ) {
                     this.settings.transformTag.call(this, tagData)
                     // re-validate after tag transformation
-                    isValid = this.validateTag(tagData.value) === true
+                    invalidCause = this.validateTag(tagData.value);
+                    isValid = invalidCause === true
                 }
                 else{
                     this.onEditTagDone(tagElm)
                     return
                 }
 
-                if( isValid !== true )
+                if( isValid !== true ) {
+                    let tagElmIdx = this.getNodeIndex(tagElm);
+                    this.trigger("edit:invalid", {
+                        tag          : tagElm,
+                        tagIndex     : tagElmIdx,
+                        tagData      : tagData,
+                        cause        : invalidCause
+                    });
                     return;
+                }
 
                 this.onEditTagDone(tagElm, tagData)
             },


### PR DESCRIPTION
When you are in edit mode and enter an invalid value the invalid value is marked. But there is no event fired in such situations. 

I had a problem when using tagify with the provided example "[Easy to customize](https://yaireo.github.io/tagify/#section-different-look)". I think the problem here is, that an empty element is added and you switch to edit-Mode immediatelly. The only thing I want to do is: remove the invalid element completely.

I don't know if there's already a solution. I could only achieve the expected behavior by adding a new event "edit:invalid" which is just triggered before exiting the method "onEditTagBlur".