### PR TITLE
Implement outputDelimiter setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,7 @@ Name                    | Type             | Default                          | 
 ----------------------- | ---------------- | -------------------------------- | --------------------------------------------------------------------------
 placeholder             | String           |                                  | Placeholder text. If this attribute is set on an input/textarea element it will override this setting
 delimiters              | String           | `,`                              | [regex string] split tags by any of these delimiters. Example: `",|`  |."`
+outputDelimiter         | String           | null                             | join tags with this character to produce the value for original input field. if null, a JSON array is produced instead
 pattern                 | String           | null                             | Validate input by REGEX pattern (can also be applied on the input itself as an attribute) Ex: `/[1-9]/`
 mode                    | String           | null                             | Use `select` for single-value dropdown-like select box. See `mix` as value to allow mixed-content. The 'pattern' setting must be set to some character.
 mixTagsInterpolator     | Array            | `['[[', ']]']`                   | Interpolation for mix mode. Everything between these will become a tag

--- a/src/tagify.js
+++ b/src/tagify.js
@@ -80,6 +80,7 @@ Tagify.prototype = {
 
     DEFAULTS : {
         delimiters          : ",",            // [RegEx] split tags by any of these delimiters ("null" to cancel) Example: ",| |."
+        outputDelimiter     : null,           // join tags with this character to produce the value for original input field
         pattern             : null,           // RegEx pattern to validate input by. Ex: /[1-9]/
         maxTags             : Infinity,       // Maximum number of tags
         callbacks           : {},             // Exposed callbacks object to be triggered on certain events
@@ -1693,7 +1694,9 @@ Tagify.prototype = {
         this.DOM.originalInput.value = this.settings.mode == 'mix'
             ? this.getMixedTagsAsString(value)
             : this.value.length
-                ? JSON.stringify(value)
+                ? (this.settings.outputDelimiter 
+                    ? value.map(({value}) => value).join(this.settings.outputDelimiter) 
+                    : JSON.stringify(value))
                 : ""
          this.DOM.originalInput.dispatchEvent(new Event('change'))
     },


### PR DESCRIPTION
If configured, the value for the original input is produced by joining
the tags with the string specified in this option. Otherwise, a JSON array is produced
as before.

----

Thanks for tagify, it does almost exactly what I need in my application. I just needed this feature to simplify integration. I thought it may be useful for others too, so feel free to pull it :)
