### PR TITLE
Escape attributes rendered in <tag> tag by a tag(tagData) template.

### DIFF
--- a/src/tagify.js
+++ b/src/tagify.js
@@ -377,7 +377,7 @@ Tagify.prototype = {
         for( i=keys.length; i--; ){
             propName = keys[i];
             if( propName != 'class' && data.hasOwnProperty(propName) && data[propName] !== undefined )
-                s += " " + propName + (data[propName] !== undefined ? `="${data[propName]}"` : "");
+                s += " " + propName + (data[propName] !== undefined ? `="${escapeHTML(String(data[propName]))}"` : "");
         }
         return s;
     },


### PR DESCRIPTION
To reproduce the issue, store any HTML code in a custom tagData field,
like this. The main use-case is a scenario of displaying some HTML:

```javascript
new Tagify(document.querySelector('#tagId'), {
    ...
    transformTag: transformTag,
    ...
    templates: {
        ...
        tag(tagData) {
            return `
                <tag ...
                    ${this.getAttributes(tagData)}
                >
                ...
                ${tagData.something}
                ...
                </tag>
            `;
        };
    },
});

function transformTag(tagData) {
    const content = "'some' content";
    tagData.something = `<span style="margin-top: 10px">${content}</span>`;
}
```

I used the internally defined `escapeHTML` function, which I also found on the same StackOverflow page before using it in my project, because sadly there doesn't seem to be any native JavaScript support to safely escape HTML tags in such a way. (Considering this is a well-known approach, I'd also **suggest exposing this function via Tagify object** to be directly accessible even for Vanilla JS users.) Alternatively, the native `encodeURI` function could be used here, but this would also replace safe characters (a space becoming %20) for no good reason. Unlike `encodeURI`, the `escapeHTML` doesn't convert the input to a string, so there's also an explicit conversion (even of values like true or null) using String().

Of course, this change can have an impact on users who depend on attributes to be rendered directly before being read from the HTML tag attribute, but I believe the default behavior should deny this when the characters are unsafe. Such attributes can't be used anyway, so I don't think anyone would like to have their DOM structure be broken, and if they do, they are free to override the tag template. Also, it's possible that some characters mentioned in `escapeHTML` don't need to be escaped, for example those other than quotes, but I can't assess the consequences of how does this impact for example the process of unescaping the characters back should it be required. In any case, this functionality could be at least exposed via optional parameter of `getAttributes`.

This PR wasn't tested on latest version due to https://github.com/yairEO/tagify/issues/586, so please make sure it doesn't break anything.