### PR TITLE
Update tagify.scss

### DIFF
--- a/src/tagify.scss
+++ b/src/tagify.scss
@@ -393,6 +393,7 @@
         white-space: pre-wrap; // #160 Line break (\n) as delimeter
         color: $input-color;
         color: var(--input-color);
+        text-align: start;
 
         &:empty{
             @include firefox {


### PR DESCRIPTION
If exists some wrapper over Tagify with `text-align: center/left/right;` this will inherit the style from parent. Probably this should be every time from start.