### PR TITLE
unaccent the needle as well as the haystack on fuzzy accentedSearch

### DIFF
--- a/src/parts/dropdown.js
+++ b/src/parts/dropdown.js
@@ -543,7 +543,7 @@ export default {
 
             if( _sd.fuzzySearch ){
                 searchBy = searchKeys.reduce((values, k) => values + " " + (whitelistItem[k]||""), "").toLowerCase()
-                valueIsInWhitelist = stringHasAll(_sd.accentedSearch ? unaccent(searchBy) : searchBy, niddle)
+                valueIsInWhitelist = stringHasAll(_sd.accentedSearch ? unaccent(searchBy) : searchBy, _sd.accentedSearch ? unaccent(niddle) : niddle)
             }
 
             else {


### PR DESCRIPTION
otherwise a searchterm with accented characters won't match any of the results. See https://github.com/openfoodfacts/openfoodfacts-server/issues/4280