### PR TITLE
fix: use only config classes for querying elements

### DIFF
--- a/src/parts/dropdown.js
+++ b/src/parts/dropdown.js
@@ -302,7 +302,7 @@ export default {
         callbacks : {
             onKeyDown(e){
                 // get the "active" element, and if there was none (yet) active, use first child
-                var activeListElm = this.DOM.dropdown.querySelector("[class$='--active']"),
+                var activeListElm = this.DOM.dropdown.querySelector("." + this.settings.classNames.dropdownItemActive),
                     selectedElm = activeListElm;
 
                 switch( e.key ){
@@ -431,7 +431,7 @@ export default {
         this.state.ddItemData = itemData
         this.state.ddItemElm = elm
 
-        // this.DOM.dropdown.querySelectorAll("[class$='--active']").forEach(activeElm => activeElm.classList.remove(className));
+        // this.DOM.dropdown.querySelectorAll("." + this.settings.classNames.dropdownItemActive).forEach(activeElm => activeElm.classList.remove(className));
         elm.classList.add(className);
         elm.setAttribute("aria-selected", true)
 


### PR DESCRIPTION
This PR fixes #695 bug happening when `tagify` is being used altogether with custom classnames.
The cause was that one of `querySelector`s was dependent on original classname instead of using configuration.
