### PR TITLE
fixes Chrome for Mac IME problem

### DIFF
--- a/src/parts/dropdown.js
+++ b/src/parts/dropdown.js
@@ -346,6 +346,8 @@ export default {
                         return true
                     }
                     case 'Enter' : {
+                        // Chrome for Mac sends Enter key event with keyCode 229 during IME composition
+                        if( e.keyCode == 229 ) return;
                         e.preventDefault();
                         this.dropdown.selectOption.call(this, activeListElm)
                         break;

--- a/src/parts/events.js
+++ b/src/parts/events.js
@@ -681,6 +681,8 @@ export default {
                     tagElm.innerHTML = tagElm.__tagifyTagData.__originalHTML
                 case 'Enter' :
                 case 'Tab' :
+                    // Chrome for Mac sends Enter key event with keyCode 229 during IME composition
+                    if( e.keyCode == 229 ) return;
                     e.preventDefault()
                     e.target.blur()
             }


### PR DESCRIPTION
Like this issue, Enter key during IME composition cause unintentional tag creation.
#539