### PR TITLE
Fix for Issue #741: Clicking on The Drop-Down Scroll Closes the Dropdown)

### DIFF
--- a/src/parts/dropdown.js
+++ b/src/parts/dropdown.js
@@ -377,7 +377,8 @@ export default {
             },
 
             onClick(e){
-                if( e.button != 0 || e.target == this.DOM.dropdown ) return; // allow only mouse left-clicks
+                if( e.button != 0 || e.target == this.DOM.dropdown) return; // allow only mouse left-clicks
+                if( e.target.classList.contains(this.settings.classNames.dropdownWrapper)) return; // if the suggestion list is long, you still want to click on the scroller
 
                 var listItemElm = e.target.closest('.' + this.settings.classNames.dropdownItem)
 


### PR DESCRIPTION
If the suggestion list is long and a scroll is shown, then clicking on the scroll should not close the drop-down.