### PR TITLE
Replace division operators in tagify.scss with math.div

### DIFF
--- a/src/tagify.scss
+++ b/src/tagify.scss
@@ -250,7 +250,7 @@
         &:focus{
             div{  // :not([contenteditable])
                 &::before{
-                    $size: -$tagMargin/2;
+                    $size: math.div(-$tagMargin, 2);
                     $size: -2px;
                     top:$size; right:$size; bottom:$size; left:$size;
                     box-shadow: 0 0 0 $tag-inset-shadow-size $tag-hover inset;
@@ -366,7 +366,7 @@
             justify-content: center;
             border-radius  : 50px;
             cursor         : pointer;
-            font           : #{$size}/1 Arial;
+            font           : #{$size} Arial;
             background     : $tag-remove-btn-bg;
             background     : var(--tag-remove-btn-bg, $tag-remove-btn-bg);
             color          : $tag-remove-btn-color;
@@ -374,7 +374,7 @@
 
             width          : $size;
             height         : $size;
-            margin-right   : $size/3;
+            margin-right   : math.div($size, 3);
             margin-left    : auto;
 
             overflow       : hidden;
@@ -569,8 +569,8 @@
             right: 0;
             bottom: 0;
             font: $size monospace;
-            line-height: $size/2;
-            height: $size/2;
+            line-height: math.div($size, 2);
+            height: math.div($size, 2);
             pointer-events: none;
             transform: translate(-150%, -50%) scaleX(1.2) rotate(90deg);
             transition: .2s ease-in-out;


### PR DESCRIPTION
The dart-based `sass` package is now throwing deprecation warnings when building with tagify:

> Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

This PR follows its recommendation and replaces the division operators with `math.div`.