### PR TITLE
Fixes add mix tag with prefix

### DIFF
--- a/src/tagify.js
+++ b/src/tagify.js
@@ -1126,7 +1126,7 @@ Tagify.prototype = {
 
         strToReplace = strToReplace || this.state.tag.prefix + this.state.tag.value;
         var idx, nodeToReplace,
-            selection = window.getSelection(),
+            selection = this.state.selection || window.getSelection(),
             nodeAtCaret = selection.anchorNode,
             firstSplitOffset = this.state.tag.delimiters ? this.state.tag.delimiters.length : 0;
 


### PR DESCRIPTION
Made `replaceTextWithNode` more resilient (and not crash) in case focus change was involved somehow between the time a popup is put up by the `prefix` and when `addMixTags()` is called.

How we ran into the issue:
* our use case calls for an external popup which unfortunately takes the focus (it's always a possibility if the popup is external).

Figure it's probably safer to use the saved selection if it exists anyway (e.g. we save one onBlur) and use `window.getSelection()` as backup. Let me know if you disagree.