### PR TITLE
add missing css color variable on suggested text

### DIFF
--- a/src/tagify.scss
+++ b/src/tagify.scss
@@ -523,6 +523,7 @@
             display: inline-block;
             white-space: pre; /* allows spaces at the beginning */
             color: $tag-text-color;
+            color: var(--tag-text-color);
             opacity: .3;
             pointer-events:none;
             max-width: 100px;


### PR DESCRIPTION
I've noticed that the suggestion text was missing a css variable for styling when i was adding dark mode to one of my sites.