### PR TITLE
Issue #1042: Tag doesn't get added on selecting value from custom template dropdownItemNoMatch

### DIFF
--- a/src/parts/dropdown.js
+++ b/src/parts/dropdown.js
@@ -512,7 +512,7 @@ export default {
         // the scenario is that "addTags" was called from a dropdown suggested option selected while editing
 
         var tagifySuggestionIdx = elm.getAttribute('tagifySuggestionIdx'),
-            tagData = this.suggestedListItems[+tagifySuggestionIdx];
+            tagData = this.suggestedListItems[+tagifySuggestionIdx] || elm.getAttribute("value");
 
         this.trigger("dropdown:select", {data:tagData, elm})
 


### PR DESCRIPTION
Fix for issue https://github.com/yairEO/tagify/issues/1042: When we use `dropdownItemNoMatch` for creatable tags, the value selected from dropdown doesn't get added as tag but remains as text.

**Fix**:
1. Considering data as value attribute of  `dropdownItemNoMatch`, as it will not have an entry in `this.suggestedListItems`.
2. User should add `tagifySuggestionIdx` to `dropdownItemNoMatch` option. Also the value attribute should be added as below:
```
  function dropdownItemNoMatch(data) {
    return `<div class='${
      this.settings.classNames.dropdownItem
    }' tagifySuggestionIdx="999" tabindex="0" role="option" value="${data.value}">
        <strong>${data.value}</strong> 
    </div>`;
  }
```