### PR TITLE
Ignore keys during IME composition

### DIFF
--- a/src/parts/dropdown.js
+++ b/src/parts/dropdown.js
@@ -390,6 +390,9 @@ export default {
             onKeyDown(e){
                 if( !this.state.hasFocus )
                     return
+                // ignore keys during IME composition
+                if( this.state.composing )
+                    return
 
                 // get the "active" element, and if there was none (yet) active, use first child
                 var selectedElm = this.DOM.dropdown.querySelector(this.settings.classNames.dropdownItemActiveSelector),

--- a/src/parts/events.js
+++ b/src/parts/events.js
@@ -58,12 +58,14 @@ export default {
 
         // setup callback references so events could be removed later
         _CBR = (this.listeners.main = this.listeners.main || {
-            focus    : ['input', _CB.onFocusBlur.bind(this)],
-            keydown  : ['input', _CB.onKeydown.bind(this)],
-            click    : ['scope', _CB.onClickScope.bind(this)],
-            dblclick : ['scope', _CB.onDoubleClickScope.bind(this)],
-            paste    : ['input', _CB.onPaste.bind(this)],
-            drop     : ['input', _CB.onDrop.bind(this)]
+            focus            : ['input', _CB.onFocusBlur.bind(this)],
+            keydown          : ['input', _CB.onKeydown.bind(this)],
+            click            : ['scope', _CB.onClickScope.bind(this)],
+            dblclick         : ['scope', _CB.onDoubleClickScope.bind(this)],
+            paste            : ['input', _CB.onPaste.bind(this)],
+            drop             : ['input', _CB.onDrop.bind(this)],
+            compositionstart : ['input', _CB.onCompositionStart.bind(this)],
+            compositionend   : ['input', _CB.onCompositionEnd.bind(this)]
         })
 
         for( var eventName in _CBR ){
@@ -206,6 +208,14 @@ export default {
             this.dropdown.hide()
         },
 
+        onCompositionStart(e){
+            this.state.composing = true
+        },
+
+        onCompositionEnd(e){
+            this.state.composing = false
+        },
+
         onWindowKeyDown(e){
             var focusedElm = document.activeElement,
                 isTag = isNodeTag.call(this, focusedElm),
@@ -237,6 +247,10 @@ export default {
 
         onKeydown(e){
             var _s = this.settings;
+
+            // ignore keys during IME composition
+            if( this.state.composing )
+                return
 
             if( _s.mode == 'select' && _s.enforceWhitelist && this.value.length && e.key != 'Tab' ){
                 e.preventDefault()
@@ -449,7 +463,7 @@ export default {
                 }
 
                 case 'Enter' :
-                    if( this.state.dropdown.visible || e.keyCode == 229 ) return
+                    if( this.state.dropdown.visible ) return
                     e.preventDefault(); // solves Chrome bug - http://stackoverflow.com/a/20398191/104380
                     // because the main "keydown" event is bound before the dropdown events, this will fire first and will not *yet*
                     // know if an option was just selected from the dropdown menu. If an option was selected,
@@ -864,6 +878,10 @@ export default {
         },
 
         onEditTagkeydown(e, tagElm){
+            // ignore keys during IME composition
+            if( this.state.composing )
+                return
+
             this.trigger("edit:keydown", {event:e})
 
             switch( e.key ){

--- a/src/tagify.js
+++ b/src/tagify.js
@@ -39,6 +39,7 @@ function Tagify( input, settings ){
     this.state = {
         inputText: '',
         editing : false,
+        composing: false,
         actions : {},   // UI actions for state-locking
         mixMode : {},
         dropdown: {},
@@ -532,6 +533,8 @@ Tagify.prototype = {
         editableElm.addEventListener('blur', delayed_onEditTagBlur)
         editableElm.addEventListener('input', _CB.onEditTagInput.bind(this, editableElm))
         editableElm.addEventListener('keydown', e => _CB.onEditTagkeydown.call(this, e, tagElm))
+        editableElm.addEventListener('compositionstart', e => _CB.onCompositionStart.call(this, e))
+        editableElm.addEventListener('compositionend', e => _CB.onCompositionEnd.call(this, e))
 
         if( !opts.skipValidation )
             isValid = this.editTagToggleValidity(tagElm)

--- a/src/tagify.js
+++ b/src/tagify.js
@@ -533,8 +533,8 @@ Tagify.prototype = {
         editableElm.addEventListener('blur', delayed_onEditTagBlur)
         editableElm.addEventListener('input', _CB.onEditTagInput.bind(this, editableElm))
         editableElm.addEventListener('keydown', e => _CB.onEditTagkeydown.call(this, e, tagElm))
-        editableElm.addEventListener('compositionstart', e => _CB.onCompositionStart.call(this, e))
-        editableElm.addEventListener('compositionend', e => _CB.onCompositionEnd.call(this, e))
+        editableElm.addEventListener('compositionstart', _CB.onCompositionStart.bind(this))
+        editableElm.addEventListener('compositionend', _CB.onCompositionEnd.bind(this))
 
         if( !opts.skipValidation )
             isValid = this.editTagToggleValidity(tagElm)


### PR DESCRIPTION
This is a reimplementation of #719

Keydown events during IME composition should be ignored, otherwise IME key strokes like Enter or arrow keys cause unintentional tagify operations. 

It's hard for CJK country users to input tags written in their native languages.  

If you aren't familiar with IME, please take a look at this article.
https://medium.com/square-corner-blog/understanding-composition-browser-events-f402a8ed5643