### PR TITLE
Fix typo in "Submit on 'Enter' key" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -787,7 +787,7 @@ tagify.on('keydown', onTagifyKeyDown)
 
 function onTagifyKeyDown(e){
   if( e.key == 'Enter' &&         // "enter" key pressed
-      !tagify.state.inputText &&  // assuming user is not in the middle oy adding a tag
+      !tagify.state.inputText &&  // assuming user is not in the middle or adding a tag
       !tagify.state.editing       // user not editing a tag
     ){
     setTimeout(() => formElm.submit())  // put some buffer to make sure tagify has done with whatever, to be on the safe-side


### PR DESCRIPTION
Fixed a small typo that confused me in understanding the logic of the `inputText` attribute state (`tagify.state.inputText`).