### PR TITLE
de-highlight item when the mouse leaves it

### DIFF
--- a/src/parts/dropdown.js
+++ b/src/parts/dropdown.js
@@ -476,7 +476,7 @@ export default {
             onMouseOver(e){
                 var ddItem = e.target.closest(this.settings.classNames.dropdownItemSelector)
                 // event delegation check
-                ddItem && this.dropdown.highlightOption(ddItem)
+                this.dropdown.highlightOption(ddItem)
             },
 
             onMouseLeave(e){


### PR DESCRIPTION
If you are using the `templates.dropdownHeader` or `templates.dropdownFooter` settings, and you mouse over them, the last active item remains highlighted.

In the example website, the Users List example has the same behaviour if you mouse hover the `Team A` / `Team B` titles: the highlight stays on an item that is not hovered with the mouse:
![image](https://github.com/yairEO/tagify/assets/183785/3424f7e6-9fe8-4c12-b569-8c14b581b42d)
