### PR TITLE
Don't hide dropdown during whitelist fetch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,8 +224,8 @@ function onInput( e ){
   controller && controller.abort()
   controller = new AbortController()
 
-  // show loading animation and hide the suggestions dropdown
-  tagify.loading(true).dropdown.hide()
+  // show loading animation.
+  tagify.loading(true)
 
   fetch('http://get_suggestions.com?value=' + value, {signal:controller.signal})
     .then(RES => RES.json())


### PR DESCRIPTION
As mentioned in https://github.com/yairEO/tagify/issues/884 and https://github.com/yairEO/tagify/issues/1275, hiding the dropdown before whitelist fetch and load may cause a few small hiccups:

* potential double entry on hitting return
* have to press down arrow twice to get into the suggestion list (oh, how terrible this is, the suffering is immense :-P )
* potential issues with highlight first

When I removed the "hide" from my code, things seemed to function more smoothly.