### PR TITLE
DO NOT MERGE - Hitting tab should autocomplete with highlighted suggestion.

### DIFF
--- a/src/parts/dropdown.js
+++ b/src/parts/dropdown.js
@@ -432,9 +432,9 @@ export default {
                                 if( this.state.actions.ArrowLeft )
                                     return
                             case 'Tab' : {
-                                let shouldAutocompleteOnKey = !_s.autoComplete.rightKey || !_s.autoComplete.tabKey
+                                let shouldAutocompleteOnKey = _s.autoComplete.rightKey || _s.autoComplete.tabKey
 
-                                // in mix-mode, treat arrowRight like Enter key, so a tag will be created
+                                // in mix-mode, treat arrowRight and Tab like Enter key, so a tag will be created
                                 if( !isMixMode && selectedElm && shouldAutocompleteOnKey && !this.state.editing ){
                                     e.preventDefault() // prevents blur so the autocomplete suggestion will not become a tag
                                     var value = this.dropdown.getMappedValue(selectedElmData)


### PR DESCRIPTION
**DO NOT MERGE** - this has some problems!

Before this change, hitting Tab doesn't cause a tag to be created in the following situation:

> <img width="384" alt="image" src="https://github.com/yairEO/tagify/assets/1637133/c3202f91-0c81-43da-8999-55ea70e3f8e1">

Hitting Tab does nothing, the selected suggestion just remains highlighted.

My tagify for this control is as follows:

```
    const tagify = new Tagify(input, {
      placeholder: 'Parents',
      editTags: false,
      autoComplete: { enabled: true, rightKey: true, tabKey: true },
      enforceWhitelist: false,
      whitelist: [],
      dropdown: {
        enabled: 2,  // Min 2 chars - this doesn't seem to work.
        maxItems: 20,
        mapValueTo: 'suggestion',  // Field to display
        placeAbove: false,  // Always put the dropdown below the textbox
      },
    });  // end tagify
```

After this change, hitting Tab in the following situation completes the tag, and then hitting Tab again actually creates the tag, as expected:

> <img width="391" alt="image" src="https://github.com/yairEO/tagify/assets/1637133/8b575455-d63e-436e-af41-f984435bdbc4">

@yairEO - I'm not sure if I'm misinterpreting something in the code ... I can't follow why the two OR'd conditions would "not-ed" with the `!` .  Perhaps the original code works in some other situation, but not mine.  Let me know if this is incorrect.  :-)  Cheers!