### PR TITLE
Stop logging input keystrokes.

### DIFF
--- a/src/parts/events.js
+++ b/src/parts/events.js
@@ -519,7 +519,7 @@ export default {
 
             eventData.isValid = validation;
 
-            console.log(this.state.inputText , value)
+            // console.log(this.state.inputText , value)
             // for IE; since IE doesn't have an "input" event so "keyDown" is used instead to trigger the "onInput" callback,
             // and so many keys do not change the input, and for those do not continue.
             if( this.state.inputText == value ) return;

--- a/src/parts/events.js
+++ b/src/parts/events.js
@@ -519,7 +519,6 @@ export default {
 
             eventData.isValid = validation;
 
-            // console.log(this.state.inputText , value)
             // for IE; since IE doesn't have an "input" event so "keyDown" is used instead to trigger the "onInput" callback,
             // and so many keys do not change the input, and for those do not continue.
             if( this.state.inputText == value ) return;


### PR DESCRIPTION
Currently tagify logs all keystrokes to the js console.  This appears to be a development/debug helper, not for prod.

Let me know if you'd like this to be a setting of some sort.