### PR TITLE
docs: fix example typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -1688,7 +1688,7 @@ function onInvalidTag(e){
   ]
 
 // Second whitelist, which is shown only when starting to type "#".
-// Thiw whitelist is the most simple one possible.
+// This whitelist is the most simple one possible.
 var whitelist_2 = ['Homer simpson', 'Marge simpson', 'Bart', 'Lisa', 'Maggie', 'Mr. Burns', 'Ned', 'Milhouse', 'Moe'];
 
 


### PR DESCRIPTION
Fix "Mix Text & Tags" typo