### PR TITLE
Remove console.log call that logs all keystrokes

### DIFF
--- a/src/parts/dropdown.js
+++ b/src/parts/dropdown.js
@@ -411,7 +411,6 @@ export default {
 
                 _s.hooks.beforeKeyDown(e, {tagify:this})
                     .then(result => {
-                        console.log(e.key);
                         switch( e.key ){
                             case 'ArrowDown' :
                             case 'ArrowUp' :


### PR DESCRIPTION
Figured I'd remove this since it's probably not intentional to let all keystrokes get logged to the console on production envs.