### PR TITLE
add missing export for css file in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
         "./dist/react.tagify": "./src/react.tagify",
         "./dist/react.tagify.jsx": "./src/react.tagify.jsx",
         "./dist/tagify.min.js": "./dist/tagify.js",
-        "./dist/tagify.min": "./dist/tagify.js"
+        "./dist/tagify.min": "./dist/tagify.js",
+        "./dist/tagify.css": "./dist/tagify.css"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
Hi, 
our build just starts failing on 

```
Module build failed (from ./node_modules/css-loader/dist/cjs.js):
Error: Can't resolve '../../../../../packages/framework/assets/styles/admin/~@yaireo/tagify/dist/tagify.css' in '/var/www/html/project-base/app/assets/styles/admin'
    at finishWithoutResolve (/var/www/html/project-base/app/node_modules/enhanced-resolve/lib/Resolver.js:564:18)
    at /var/www/html/project-base/app/node_modules/enhanced-resolve/lib/Resolver.js:656:15
    at /var/www/html/project-base/app/node_modules/enhanced-resolve/lib/Resolver.js:714:5
    at eval (eval at create (/var/www/html/project-base/app/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:15:1)
    at /var/www/html/project-base/app/node_modules/enhanced-resolve/lib/Resolver.js:714:5
    at eval (eval at create (/var/www/html/project-base/app/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:27:1)
    at /var/www/html/project-base/app/node_modules/enhanced-resolve/lib/DescriptionFilePlugin.js:89:43
    at /var/www/html/project-base/app/node_modules/enhanced-resolve/lib/Resolver.js:714:5
    at eval (eval at create (/var/www/html/project-base/app/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:15:1)
    at /var/www/html/project-base/app/node_modules/enhanced-resolve/lib/Resolver.js:714:5
    at eval (eval at create (/var/www/html/project-base/app/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:16:1)
    at /var/www/html/project-base/app/node_modules/enhanced-resolve/lib/Resolver.js:714:5
    at eval (eval at create (/var/www/html/project-base/app/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:16:1)
    at /var/www/html/project-base/app/node_modules/enhanced-resolve/lib/Resolver.js:714:5
    at eval (eval at create (/var/www/html/project-base/app/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:27:1)
    at /var/www/html/project-base/app/node_modules/enhanced-resolve/lib/DescriptionFilePlugin.js:89:43
    at /var/www/html/project-base/app/node_modules/enhanced-resolve/lib/Resolver.js:714:5
    at eval (eval at create (/var/www/html/project-base/app/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:16:1)
    at /var/www/html/project-base/app/node_modules/enhanced-resolve/lib/Resolver.js:714:5
    at eval (eval at create (/var/www/html/project-base/app/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:15:1)
    at /var/www/html/project-base/app/node_modules/enhanced-resolve/lib/DirectoryExistsPlugin.js:41:15
    at process.processTicksAndRejections (node:internal/process/task_queues:81:21)
```

The CSS file is imported in our *.less file and processed by Webpack
```
@import "~@yaireo/tagify/dist/tagify.css";
```

Adding the proposed export fixes the problem on our end. 
If it's intentional and the CSS file should be used differently, I would appreciate the info :) 

Thanks 