### PR TITLE
Fixed package.json main attribute after .min file removal

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "preset": "jest-puppeteer"
     },
     "author": "Yair Even-Or <vsync.design@gmail.com>",
-    "main": "./dist/tagify.min.js",
+    "main": "./dist/tagify.js",
     "exports": {
         ".": {
             "import": "./dist/tagify.esm.js",


### PR DESCRIPTION
This is an important fix as since 4.25.0 the "main" attribute is broken and causes issues when including tagify in some build processes

@yairEO Could you make a release after including this PR?