### PR TITLE
Fix error when DOM element is already detached during call to destroy method

### DIFF
--- a/src/tagify.js
+++ b/src/tagify.js
@@ -300,7 +300,7 @@ Tagify.prototype = {
      */
     destroy(){
         this.events.unbindGlobal.call(this)
-        this.DOM.scope.parentNode.removeChild(this.DOM.scope)
+        this.DOM.scope.parentNode && this.DOM.scope.parentNode.removeChild(this.DOM.scope)
         this.DOM.originalInput.tabIndex = this.DOM.originalInput_tabIndex
         delete this.DOM.originalInput.__tagify
         this.dropdown.hide(true)


### PR DESCRIPTION
This adds a check to the destroy method whether the `this.DOM.scope.parentNode` exists before accessing it to remove `this.DOM.scope`.

`this.DOM.scope.parentNode` can be null when the element was already removed from the DOM. The `destroy` method then throws an error. This is bad because the following code won't run anymore, and e.g. the listeners set via `setInterval` won't get cleared anymore. [It seems you had already considered this case here](https://github.com/yairEO/tagify/blob/98fba808060394914eb4a056140a965ebedd3351/src/parts/events.js#L705C1-L709C1):

```js
        observeOriginalInputValue(){
            // if, for some reason, the Tagified element is no longer in the DOM,
            // call the "destroy" method to kill all references to timeouts/intervals
            if( !this.DOM.originalInput.parentNode ) this.destroy()
```

But that doesn't quite work yet, since `destroy` throws when `this.DOM.originalInput.parentNode` is `null`.

For context, we came across this issue when we wrapped tagify as [PrimeFaces](https://www.primefaces.org/) widget. This UI framework [first detaches widgets from the DOM, then calls their destroy method](https://github.com/primefaces/primefaces/blob/de5fd5fe2f103c0d9d02c74cea7dd84ede12aa8a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js#L1386-L1396). As a result, the `setInterval` kept getting fired and tagify tried to destroy itself over and over again, resulting in many error messages getting logged.

---

You can reproduce like this:

https://jsfiddle.net/blutorange/9ers8qtp/

```html
<html>
  <body>
  <div id="container">
     <input id="myTag">
     <button id="detach-destroy">remove from DOM</button>  
  </div>
  </body>
</html>
```

```js
instance = new Tagify(document.getElementById("myTag"))
document.getElementById("detach-destroy").addEventListener("click", () => {
  instance.DOM.scope.remove();
  document.getElementById("myTag").remove();
});
```

[Screencast from 2024-10-08 19-31-44.webm](https://github.com/user-attachments/assets/2a8723d6-7b7e-43b2-ba56-e495713b0704)
