### PR TITLE
Prevent XSS in the tail of substring

### DIFF
--- a/src/tagify.js
+++ b/src/tagify.js
@@ -1170,6 +1170,7 @@ Tagify.prototype = {
                 tagElm.classList.add(this.settings.classNames.tagNoAnimation)
 
                 s2[0] = tagElm.outerHTML //+ "&#8288;"  // put a zero-space at the end so the caret won't jump back to the start (when the last input's child element is a tag)
+                s2[1] = escapeHTML(s2[1])
                 this.value.push(tagData)
             }
             else if(s1)


### PR DESCRIPTION
This PR fixes a possible XSS issue by making sure that text input is handled the same way as tag values. [Tagify already escapes HTML in tags](https://github.com/yairEO/tagify/blob/e15abdb88f2536b5f04d4f88e93cde375fdc8594/src/tagify.js#L1544) to prevent XSS, and this PR adds the same protection for regular text input.