### PR TITLE
Fix dropdown stays open

### DIFF
--- a/src/parts/events.js
+++ b/src/parts/events.js
@@ -720,7 +720,7 @@ export default {
                 this.state.hasFocus = false
 
                 // do not hide the dropdown if a click was initiated within it and that dropdown belongs to this Tagify instance
-                if( e.target.closest('.tagify__dropdown') && e.target.closest('.tagify__dropdown').__tagify != this )
+                if( e.target.closest('.tagify__dropdown') == null || e.target.closest('.tagify__dropdown').__tagify != this )
                     this.dropdown.hide()
             }
         },


### PR DESCRIPTION
Hi @yairEO I will push a bit of PRs in the coming days to fix some annoying issues I found, so I'm keeping descriptions short. If you have any question fell free to ask.

This PR fixes the dropdown staying open in some rare cases even when clicking outside the tagify instance.
See [jsbin](https://jsbin.com/fivevaxuke/edit?html,js,console,output), if you wiggle around a bit (choose a value, delete the input using the keyboard only, choose another with keyboard, now try to click outside with mouse) you will eventually occur in the bug. Sometimes you may be lucky and get the bug at the first mouse click.