### PR TITLE
Fix dropdown stays open and keeping focus

### DIFF
--- a/src/parts/events.js
+++ b/src/parts/events.js
@@ -190,13 +190,12 @@ export default {
             }
 
             // should only loose focus at this point if the event was not generated from within a tag
-            if( isFocused || nodeTag ) {
+            if( isFocused || nodeTag )
                 this.state.hasFocus = +new Date()
-                this.toggleFocusClass(this.state.hasFocus)
-            }
-            else {
+            else
                 this.state.hasFocus = false;
-            }
+            
+            this.toggleFocusClass(this.state.hasFocus)
 
             if( _s.mode == 'mix' ){
                 if( isFocused ){

--- a/src/parts/events.js
+++ b/src/parts/events.js
@@ -720,7 +720,7 @@ export default {
                 this.state.hasFocus = false
 
                 // do not hide the dropdown if a click was initiated within it and that dropdown belongs to this Tagify instance
-                if( e.target.closest('.tagify__dropdown') && e.target.closest('.tagify__dropdown').__tagify != this )
+                if( e.target.closest('.tagify__dropdown') == null || e.target.closest('.tagify__dropdown').__tagify != this )
                     this.dropdown.hide()
             }
         },

--- a/src/parts/events.js
+++ b/src/parts/events.js
@@ -190,7 +190,8 @@ export default {
             }
 
             // should only loose focus at this point if the event was not generated from within a tag
-            if( isFocused || nodeTag )
+            // select mode always generates events within a tag, so exclude it
+            if( isFocused || nodeTag && _s.mode != 'select')
                 this.state.hasFocus = +new Date()
             else
                 this.state.hasFocus = false;

--- a/src/parts/suggestions.js
+++ b/src/parts/suggestions.js
@@ -97,6 +97,10 @@ export default {
                                     this.input.autocomplete.set.call(this, value)
                                     return false
                                 }
+                                
+                                //the user is escaping from the input in select mode
+                                isSelectMode && this.dropdown.hide()
+
                                 return true
                             }
                             case 'Enter' : {


### PR DESCRIPTION
Sorry - rebuild to reorganize my repository! New PRs will come shortly.

Hi @yairEO I will push a bit of PRs in the coming days to fix some annoying issues I found, so I'm keeping descriptions short. If you have any question fell free to ask.

This PR fixes the dropdown staying open in some rare cases even when clicking outside the tagify instance.
See [jsbin](https://jsbin.com/fivevaxuke/edit?html,js,console,output), if you wiggle around a bit (choose a value, delete the input using the keyboard only, choose another with keyboard, now try to click outside with mouse) you will eventually occur in the bug. Sometimes you may be lucky and get the bug at the first mouse click.

Edit:
Add also related commit regarding the input not losing the focus border when navigating with Tab. To reproduce: Navigate with Tab over the input, you'll see that the focus class is not removed. This happens because in the code we are updating the focus state only when it is true, and not when is false.