### PR TITLE
Delete key select

### DIFF
--- a/src/parts/events.js
+++ b/src/parts/events.js
@@ -164,6 +164,9 @@ export default {
                 // if clicked anywhere else inside a tag, which had triggered an `focusin` event,
                 // the onFocusBlur should be aborted. This part was spcifically written for `select` mode.
                 // tagTextNode && this.events.callbacks.onEditTagFocus.call(this, nodeTag)
+
+                // this fixes select mode input focus lost, to trigger: Tab into it, delete (backspace) without moving caret
+                _s.mode == 'select' && this.events.callbacks.onEditTagFocus.call(this, nodeTag)
             }
 
             var text = e.target ? this.trim(this.DOM.input.textContent) : '', // a string
@@ -246,6 +249,8 @@ export default {
                     // if nothing has changed (same display value), do not add a tag
                     if( currentDisplayValue === text )
                         text = ''
+                    else //the input is empty, we should now remove the tag
+                        this.removeTags()
                 }
 
                 shouldAddTags = text && !this.state.actions.selectOption && _s.addTagOnBlur && _s.addTagOn.includes('blur');

--- a/src/parts/suggestions.js
+++ b/src/parts/suggestions.js
@@ -290,6 +290,14 @@ export default {
             isMixMode = _s.mode == 'mix',
             tagData = this.suggestedListItems.find(item => (item.value ?? item) == value)
 
+        // select mode: after the tag has been removed and focus is lost, trying to click a suggestion (after focusing again) will fail because it tries to replace an inexistent tag
+        // catch and use addTags() instead. This happens only once
+        if(_s.mode == 'select' && !this.state.composing) {
+            this.addTags(value, true)
+            closeOnSelect && this.dropdown.hide()
+            return;
+        }
+
         // The below event must be triggered, regardless of anything else which might go wrong
         this.trigger('dropdown:select', {data:tagData, elm, event})
 

--- a/src/parts/suggestions.js
+++ b/src/parts/suggestions.js
@@ -96,7 +96,11 @@ export default {
                                     this.state.autoCompleteData = selectedElmData;
                                     this.input.autocomplete.set.call(this, value)
                                     return false
+                                } else if(isSelectMode && _s.userInput && !_s.autoComplete.tabKey) { // do not forget to hide the dropdown in select mode!
+                                    this.dropdown.hide()
+                                    return false
                                 }
+                                
                                 return true
                             }
                             case 'Enter' : {
@@ -295,6 +299,7 @@ export default {
         if(_s.mode == 'select' && !this.state.composing && this.userInput) {
             this.addTags(value, true)
             closeOnSelect && this.dropdown.hide()
+            setTimeout(()=> this.DOM.scope.querySelector('.' + _s.classNames.tagText).focus(), 0) //set the focus back to input on each select to ensure consistent behavior
             return;
         }
 

--- a/src/parts/suggestions.js
+++ b/src/parts/suggestions.js
@@ -292,7 +292,7 @@ export default {
 
         // select mode: after the tag has been removed and focus is lost, trying to click a suggestion (after focusing again) will fail because it tries to replace an inexistent tag
         // catch and use addTags() instead. This happens only once
-        if(_s.mode == 'select' && !this.state.composing) {
+        if(_s.mode == 'select' && !this.state.composing && this.userInput) {
             this.addTags(value, true)
             closeOnSelect && this.dropdown.hide()
             return;


### PR DESCRIPTION
1: When you Tab into the input and then immediately click backspace the focus was lost. This PR fixes the behavior by only removing tags after blur, so that we can still write into the input.

2: Previously the focus class remained even after leaving the input, fixed by adding a "Tab" handler for select mode too.

3: Previously the dropdown stayed open when navigating with tab key (related to point 2), fixed by adding a "Tab" handler for select mode too.

4: The input focus was inconsistent on suggestion selection with a tag present or not, fixed by regaining focus to the input every time a suggestion is clicked.