### PR TITLE
Prevent dropdown from showing twice

### DIFF
--- a/src/parts/events.js
+++ b/src/parts/events.js
@@ -1010,8 +1010,13 @@ export default {
                     break
                 }
                 case 'Enter' :
-                case 'Tab' : {
                     e.preventDefault()
+                case 'Tab' : {
+                    // select mode: prevent dropdown from showing twice when user clicks inside the input and then use "Tab" to get out
+                    if(this.settings.mode !== 'select')
+                        e.preventDefault();
+                    else
+                        this.toggleFocusClass(false);
 
                     var EDITED_TAG_BLUR_DELAY = 0;
 


### PR DESCRIPTION
In select mode the dropdown will show twice when clicking inside input and then using "Tab" key to get out. Separated "Enter" and "Tab" cases and added conditional to remove blur if `mode === select`


https://github.com/user-attachments/assets/533ee6a9-520f-4b13-8b41-28a16cf9c5e3

