### PR TITLE
Fix scroll behavior

### DIFF
--- a/src/tagify.scss
+++ b/src/tagify.scss
@@ -626,7 +626,7 @@
     }
 
     // Since the dropdown is an external element, which is positioned directly on the body element
-    // it cannot ingerit the CSS variables applied on the ".Tagify" element
+    // it cannot inherit the CSS variables applied on the ".Tagify" element
     &__dropdown{
         $dropdown: &;
         $trans: .3s;
@@ -663,6 +663,7 @@
         }
 
         &__wrapper{
+            scroll-behavior: auto; // keep up/down arrow pressed to see the effect without this
             max-height: var(--tagify-dd-max-height);
             overflow: hidden;
             overflow-x: hidden;


### PR DESCRIPTION
When keeping the up/down arrow pressed the dropdown moves very slowly because of the animation. The dropdown should not have it


https://github.com/user-attachments/assets/01591740-d266-40a0-8536-c703d0e98fb3

