### PR TITLE
Keep highlight in select mode

### DIFF
--- a/src/parts/suggestions.js
+++ b/src/parts/suggestions.js
@@ -111,9 +111,24 @@ export default {
                                     .then(() => {
                                         if( selectedElm ){
                                             this.dropdown.selectOption(selectedElm)
-                                            // highlight next option
-                                            selectedElm = this.dropdown.getNextOrPrevOption(selectedElm, !actionUp)
-                                            this.dropdown.highlightOption(selectedElm)
+
+                                            if (!isSelectMode) { // highlight next option
+                                                selectedElm = this.dropdown.getNextOrPrevOption(selectedElm, !actionUp)
+                                                this.dropdown.highlightOption(selectedElm)
+                                            } else { // in select mode this never worked. It is also better to keep the highlight in the same spot after selection
+                                                setTimeout(() => {
+                                                    let refs = this.dropdown.getAllSuggestionsRefs()
+                                                    let selectedElm = null
+                                                    refs.forEach(elem => {
+                                                        if (elem.getAttribute('value') == selectedElmData.value) {
+                                                            selectedElm = elem
+                                                            return
+                                                        }
+                                                    })
+
+                                                    selectedElm != null && this.dropdown.highlightOption(selectedElm, true)
+                                                }, 0, selectedElmData) //wait for the dropdown to be redrawn
+                                            }
                                             return
                                         }
                                         else

--- a/src/parts/suggestions.js
+++ b/src/parts/suggestions.js
@@ -120,7 +120,7 @@ export default {
                                                     let refs = this.dropdown.getAllSuggestionsRefs()
                                                     let selectedElm = null
                                                     refs.forEach(elem => {
-                                                        if (elem.getAttribute('value') == selectedElmData.value) {
+                                                        if (selectedElmData && elem.getAttribute('value') == selectedElmData.value) {
                                                             selectedElm = elem
                                                             return
                                                         }


### PR DESCRIPTION
Currently when you select a suggestion from the dropdown (with keyboard control), the highlight will return to the top (without scrolling either) and to return to the point you were before you need to scroll endlessly again. This PR fixes the behavior by keeping highlight in the same spot (also, did you notice that the code to highlight the next option never worked? At least in select mode, didn't try anything else).

A real case scenario: A user scroll down with arrows and by mistake selects the wrong value, now he has to scroll down again to were it was, not very user friendly!

And here is the video (the commit there miss the `true` in `highlightOption` that I added later to fix highlighting when dropdown is filtered, but is the same for that matter)

https://github.com/user-attachments/assets/7fac6d84-938b-46a3-a7b8-35769837e03e


