### PR TITLE
Fix suggestions when using select all

### DIFF
--- a/src/parts/events.js
+++ b/src/parts/events.js
@@ -279,6 +279,7 @@ export default {
                 isBelong = withinTag && this.DOM.scope.contains(focusedElm),
                 isInputNode = focusedElm === this.DOM.input,
                 isReadyOnlyTag = isBelong && focusedElm.hasAttribute('readonly'),
+                tagText = this.DOM.scope.querySelector('.' + this.settings.classNames.tagText),
                 nextTag;
 
             if( !this.state.hasFocus && (!isBelong || isReadyOnlyTag) || isInputNode ) return;
@@ -320,7 +321,7 @@ export default {
 
                 default: {
                     //let the suggestions flow when onInput doesn't trigger because the focus is on tagText
-                    if( !_s.readonly && e.target !== null && this.DOM.scope.querySelector('.' + this.settings.classNames.tagText) === e.target ){
+                    if( !_s.readonly && e.target !== null && tagText === e.target ){
                         this.state.inputText = e.target.innerText //this must be updated manually 
                         setTimeout(() => this.events.callbacks.onInput.call(this, e), 0)
                     }

--- a/src/parts/events.js
+++ b/src/parts/events.js
@@ -321,7 +321,7 @@ export default {
                 default: {
                     //let the suggestions flow when onInput doesn't trigger because the focus is on tagText
                     if( !_s.readonly && e.target !== null && this.DOM.scope.querySelector('.' + this.settings.classNames.tagText) === e.target ){
-                        this.state.inputText = t.target.innerText //this must be updated manually 
+                        this.state.inputText = e.target.innerText //this must be updated manually 
                         setTimeout(() => this.events.callbacks.onInput.call(this, e), 0)
                     }
                 }

--- a/src/parts/events.js
+++ b/src/parts/events.js
@@ -288,16 +288,6 @@ export default {
             var targetIsRemoveBtn = e.target.classList.contains(_s.classNames.tagX);
 
             switch( e.key ){
-                // remove tag if has focus
-                case 'Backspace': {
-                    if( !_s.readonly && !this.state.editing ) {
-                        this.removeTags(focusedElm);
-                        (nextTag ? nextTag : this.DOM.input).focus()
-                    }
-
-                    break;
-                }
-
                 case 'Enter': {
                     if( targetIsRemoveBtn ) {
                         this.removeTags( e.target.parentNode )
@@ -315,6 +305,25 @@ export default {
                     if( !this.state.dropdown.visible && _s.mode != 'mix' )
                         this.dropdown.show()
                     break;
+                }
+
+                case 'Tab': //prevent Tab from falling into default case
+                    break;
+
+                // remove tag if has focus
+                case 'Backspace': {
+                    if( !_s.readonly && !this.state.editing ) {
+                        this.removeTags(focusedElm);
+                        (nextTag ? nextTag : this.DOM.input).focus()
+                    }
+                }
+
+                default: {
+                    //let the suggestions flow when onInput doesn't trigger because the focus is on tagText
+                    if( !_s.readonly && e.target !== null && this.DOM.scope.querySelector('.' + this.settings.classNames.tagText) === e.target ){
+                        this.state.inputText = t.target.innerText //this must be updated manually 
+                        setTimeout(() => this.events.callbacks.onInput.call(this, e), 0)
+                    }
                 }
             }
         },
@@ -534,7 +543,7 @@ export default {
             if( _s.mode == 'mix' )
                 return this.events.callbacks.onMixTagsInput.call(this, e);
 
-            var value = this.input.normalize.call(this, undefined, {trim: false}),
+            var value = this.input.normalize.call(this, e.target, {trim: false}), //use e.target (which could be undefined) instead of undefined directly to handle onWindowKeyDown calls
                 showSuggestions = value.length >= _s.dropdown.enabled,
                 eventData = {value, inputElm:this.DOM.input},
                 validation = this.validateTag({value});


### PR DESCRIPTION
Hi @yairEO this should be my last PR, take your time to review and/or improve them and ask me if you need any clarifications!

To trigger this bug (mode is select with whitelist):
1. Select a value
2. Close the dropdown
3. Tab into the input
4. Select all (ctrl+A/cmd+A)
5. Write something (the beginning of another value)
6. No suggestion shows up

I think this happens because the focus is not on the input but rather on the `tagText` element, fixed the behavior by adding another case to `onWindowKeyDown` handler that calls the `onInput` handler.

https://github.com/user-attachments/assets/43e10ea6-b3e1-4b3e-87e4-739c9494a40c

