### PR TITLE
Fix Tab key after click

### DIFF
--- a/src/parts/events.js
+++ b/src/parts/events.js
@@ -279,9 +279,10 @@ export default {
                 isBelong = withinTag && this.DOM.scope.contains(focusedElm),
                 isInputNode = focusedElm === this.DOM.input,
                 isReadyOnlyTag = isBelong && focusedElm.hasAttribute('readonly'),
+                tagText = this.DOM.scope.querySelector('.' + this.settings.classNames.tagText),
                 nextTag;
 
-            if( !this.state.hasFocus && (!isBelong || isReadyOnlyTag) || isInputNode ) return;
+            if( !(e.key === 'Tab' && this.state.dropdown.visible) && !this.state.hasFocus && (!isBelong || isReadyOnlyTag) || isInputNode ) return;
 
             nextTag = focusedElm.nextElementSibling;
 
@@ -314,6 +315,11 @@ export default {
                     // if( _s.mode == 'select' ) // issue #333
                     if( !this.state.dropdown.visible && _s.mode != 'mix' )
                         this.dropdown.show()
+                    break;
+                }
+
+                case 'Tab': {
+                    tagText?.focus();
                     break;
                 }
             }


### PR DESCRIPTION
Tab key didn't work after you select a suggestion with mouse because the input lose focus (tested on [jsbin](https://jsbin.com/peretadopi/1/edit?html,js,console,output) too).

Click input, select suggestion then try to Tab. Focus is lost and dropdown stays open, fixed by giving back focus to the input.

https://github.com/user-attachments/assets/d535b93b-8c9a-4208-99b2-88592e40f5de