### PR TITLE
Fix selectOption failure

### DIFF
--- a/src/tagify.js
+++ b/src/tagify.js
@@ -634,6 +634,9 @@ Tagify.prototype = {
         }
 
         if( tagElm && veryfyTagTextProp() ){
+            if(!tagElm.parentNode)
+                return;
+
             tagElm = this.replaceTag(tagElm, tagData)
             this.editTagToggleValidity(tagElm, tagData)
 


### PR DESCRIPTION
In some rare cases selectOption will fail because parentNode is null. I must say this does not happen on jsbin. To trigger it I did:
1. Click on the input without entering edit mode so no caret (clicking on the borders outside of text trigger this for me)
2. Select an option

Now the first click will fail and I have to click twice, this happens because for some reason `tagElm` (which is equal in this case to `this.state.editing.scope`) refers to an old element that is already removed from the page. Simply skipping the `replaceTag` if parentNode is null is enough to fix this

See video with error too:

https://github.com/user-attachments/assets/e65d02e4-8676-4d0c-8bff-aeecbfe5a98c