### PR TITLE
fix(parts): fix press enter to break line before a tag in mixed mode

### DIFF
--- a/src/parts/events.js
+++ b/src/parts/events.js
@@ -1,4 +1,4 @@
-import { decode, extend, getfirstTextNode, isChromeAndroidBrowser, isNodeTag, isWithinNodeTag, injectAtCaret, getSetTagData, fixCaretBetweenTags, placeCaretAfterNode } from './helpers'
+import { decode, extend, getfirstTextNode, isChromeAndroidBrowser, isNodeTag, isWithinNodeTag, injectAtCaret, getSetTagData, fixCaretBetweenTags, placeCaretAfterNode, fixCaretBeforeTag } from './helpers'
 import {ZERO_WIDTH_CHAR} from './constants'
 
 export function triggerChangeEvent(){
@@ -343,6 +343,10 @@ export default {
 
             if( _s.mode == 'select' && _s.enforceWhitelist && this.value.length && e.key != 'Tab' ){
                 e.preventDefault()
+            }
+
+            if (_s.mode === 'mix' && e.key === 'Enter') {
+                fixCaretBeforeTag.call(this);
             }
 
             var s = this.trim(e.target.textContent);

--- a/src/parts/helpers.js
+++ b/src/parts/helpers.js
@@ -327,3 +327,32 @@ export function fixCaretBetweenTags(tags, TagifyHasFocuse) {
     })
 }
 
+/**
+ * Fixes caret positioning before tag elements by inserting a zero-width character.
+ * Prevents the cursor from becoming invisible when positioned directly before tag elements.
+ */
+export function fixCaretBeforeTag() {
+  var sel = window.getSelection();
+  var range = sel.getRangeAt(0);
+
+  if (!sel.rangeCount) return;
+
+  var { endContainer, endOffset } = range;
+  var { nodeType, length, parentNode, nextSibling } = endContainer;
+
+  if (
+    nodeType === 3 &&
+    endOffset === length &&
+    parentNode &&
+    parentNode.classList.contains(this.settings.classNames.input) &&
+    isNodeBelongsToThisTagifyInstance.call(this, nextSibling)
+  ) {
+    var textNode = document.createTextNode(ZERO_WIDTH_CHAR);
+
+    range.setEnd(parentNode.insertBefore(textNode, nextSibling), 0);
+    range.collapse(false);
+    sel.removeAllRanges();
+    sel.addRange(range);
+  }
+}
+


### PR DESCRIPTION
### Bug: Pressing Enter before the tag element adds an unwanted new line in Mixed-Mode

### Reproduce

![reproduce](https://github.com/user-attachments/assets/7d9233c8-bc03-44bd-a028-fd00c06c7ea9)

### Fixed

![fixed](https://github.com/user-attachments/assets/7a57403f-a349-4527-86af-d343b457efa8)
