### PR TITLE
Update helpers.js  placeCaretAfterNode

### DIFF
--- a/src/parts/helpers.js
+++ b/src/parts/helpers.js
@@ -300,9 +300,10 @@ export function placeCaretAfterNode( node ){
 
     var nextSibling = node,
         sel = window.getSelection(),
-        range = sel.getRangeAt(0);
+        range;
 
     if (sel.rangeCount) {
+        range = sel.getRangeAt(0);
         range.setStartAfter(nextSibling);
         range.collapse(true)
         // range.setEndBefore(nextSibling || node);


### PR DESCRIPTION
The rangeCount must be checked first, and then getRangeAt.Otherwise, an error [Failed to execute 'getRangeAt' on 'Selection': 0 is not a valid index] will be throw