### PR TITLE
Allow caret navigation between tags to insert tags in between

### DIFF
--- a/.cursor/commands/commit-msg.md
+++ b/.cursor/commands/commit-msg.md
@@ -1,0 +1,352 @@
+# Git Commit Message Generation Guidelines
+
+## User Intent: Execute Commit
+
+If the user asks to **commit** (e.g., types "commit" or "and commit" when invoking this command), then after generating the commit message you MUST run the commit:
+
+```bash
+# Messages are usually multiline (subject + body). Use multiple -m flags or pipe:
+git commit -m "<subject>" -m "<body>"
+# Or for complex body: pipe the full message
+printf '%s' "<full generated message>" | git commit -F -
+```
+
+So the flow is: generate the message → run `git commit` → then print the commit message to the user so they can see what was committed. If the user does not ask to commit, output only the message for copy-pasting.
+
+## Mandatory Verification Checklist
+
+Before responding, you MUST explicitly acknowledge (internally, without any output) that you have completed each of these steps:
+
+[ ] I have read `definity.mdc` & `system-patterns.mdc` for a better overall understanding of this project
+[ ] I have checked for staged files with `git diff --staged --name-only`
+[ ] I have used `git diff --staged | cat` (if files are staged) or `git diff | cat` (if no files are staged) to review all changes
+[ ] I have analyzed the purpose of changes across all files
+[ ] I have identified the proper type and scope for this commit
+[ ] I will format my commit message according to the required template
+[ ] I will Check for similar changes, and if detected, consolidate those changes, without specifying the files changes, and simply outline the changes in a broad manner. Only do step 8 if there are files with specific changes to them which weren't done similarly in other files.
+[ ] I will include file-specific analysis in the commit message body
+[ ] I reviewed the final output to be certain each list-item belongs to that list. if not, move it to the list of the file it belongs to
+
+If you have not completed any of these steps, stop immediately and complete them before proceeding.
+
+## Format Verification Steps
+
+To ensure correct format implementation, follow these steps:
+
+1. Implement a stricter checklist approach - read each section of rule files completely before responding
+2. For format-specific instructions, extract and follow the exact template provided
+3. Double-check your response against the rule specifications before submitting
+4. When specific formats are required, parse those requirements first before focusing on content
+
+Remember that correct formatting is equally important as content accuracy. The nested markdown format with triple backticks inside triple backticks is required for all commit message suggestions.
+
+
+## Efficiency Guidelines
+
+## Structure
+
+```
+<type>(<scope>): <subject>
+
+[optional body with per-file analysis]
+```
+
+## Types
+- `feat`: New feature
+- `fix`: Bug fix
+- `refactor`: Code change that neither fixes a bug nor adds a feature
+- `style`: Changes that do not affect the meaning of the code
+- `docs`: Documentation only changes
+- `test`: Adding missing tests or correcting existing tests
+- `chore`: Changes to the build process or auxiliary tools
+- `perf`: Performance improvements
+
+## Best Practices
+
+1. First line:
+   - Maximum 72 characters
+   - No period at the end
+   - Capitalize first letter
+
+2. When to use body:
+   - Complex changes requiring explanation
+   - Breaking changes
+   - Major refactoring
+   - Security-related changes
+
+3. Multiple changes:
+   - Use bullet points in body
+   - Each point starts with a hyphen
+   - Indent with 2 spaces
+   - Be a bit more specific regarding changes in each file and how they are linked to each other. analyze all the files one by one AND as a whole.
+
+4. Technical specificity:
+   - Wrap function/method names, prop names, parameters, and file references in backticks (e.g., `isCompute`, `usePerformanceData`, `Tag.tsx`)
+   - For parameter changes, state the change clearly: "Add `paramName` parameter with default value `true`"
+   - For signature changes, specify before and after (e.g., "Change `functionName` signature from `(a, b)` to `(a, b, c?)`")
+   - Describe what changed, not why or what the purpose is, unless it can be infered with over 90% accuracy
+   - Avoid ambiguous phrases like "improve handling" or "for better performance"
+   - Use technical language that reflects actual code changes
+   - Focus on facts, not interpretation
+   - **Do not speculate** about intent, business logic, or downstream effects
+   - Consolidate related changes: when removing/extracting code, group associated imports/exports together (e.g., "Remove `hookName` definition and associated imports" instead of listing each import separately)
+
+## Output Format
+markdown within a codeblock, for easier copy-pasting as a commit message in GIT
+
+
+## Detailed File Analysis Format
+
+Commit messages should include a per-file breakdown of changes, following this structure:
+
+```
+refactor(UI): brief overall description of changes
+
+FileA.tsx:
+[follow previous section "Write message focusing on"]
+
+FileB.ts:
+[follow previous section "Write message focusing on"]
+```
+
+This format makes it easier to understand:
+- What changed in each file
+- The relationship between changes across files
+- The impact of the changes
+- When listing files, use only the filename (e.g., `FileA.tsx`) and not its full path.
+
+## Examples of Bad & Good Specificity
+
+Bad:
+```
+refactor(TimeChart): improve time units handling
+
+- Update function parameters to be more flexible
+- Fix conditional logic for better compatibility
+- Enhance tests to cover more scenarios
+- Add helpful TODO comment for future maintainers
+```
+
+Good (concise, factual):
+```
+refactor(TimeChart): replace boolean flag with string parameter for time units
+
+- Change `getOptimalStepAndLines` signature from `(range, targetLines, isTimeUnits: boolean)` to `(range, targetLines, units?: string)`
+- Update conditional in `getOptimalStepAndLines` to check `if units === "seconds"` instead of boolean flag
+- Remove `isTimeUnits` variable in `getGridYValues` function, directly pass `units` parameter
+- Update test cases to use string parameter instead of boolean
+```
+
+Excellent (per-file, concise, factual):
+```
+refactor(UI): centralize component types and styling
+
+TasksTableTaskTypeCell.tsx:
+- Replace `{ value: string }` type with `GridRenderCellParams<Task, string>`
+- Improved type safety
+
+ComparativeChangeCount.tsx:
+- Remove component-specific chip styling from `CHIP_SX` constant
+- Keep only fontWeight property in local styling
+
+theme.ts:
+- Create global `MuiChip` style configuration in theme
+- Move chip background styling and color variant rules from component to theme
+- Implement class selectors using `chipClasses` constants
+```
+
+## Avoiding Implementation Noise
+
+Focus on **semantic changes** and **functional impact**, not implementation details:
+
+**DO NOT include:**
+- Specific CSS class names or Tailwind utilities (e.g., "added `flex items-center gap-1`")
+- Styling property details (e.g., "positioned inline with icon and styled with text-xs -ml-0.5")
+- Intermediate value transformations (e.g., "via `count={withCount ? count : undefined}`")
+- Layout mechanics that don't affect logic (e.g., "update sizing to accommodate badge")
+- Individual className modifications that are styling concerns only (unless the git-staged changes are mainly about that)
+- Every single code change (e.g., each `?.` operator or type annotation)
+- Cosmetic details that don't affect functionality
+- `import` statements
+
+**DO include:**
+- Prop additions/modifications and their types
+- Data flow through component hierarchy
+- Conditional logic at a high level (e.g., "when count > 1")
+- Component behavior changes that are semantically important
+- New elements/components being rendered
+- The cohesive idea binding all changes together
+
+**Anti-Pattern (speculative, verbose):**
+```
+ComponentName.tsx:
+- Imported "foo.constants" file
+- Add `data-test-id="compare-runs--swap-groups-btn"` attribute for test selector targeting
+- Add size constraint to LightBulbIcon with `className="w-5! h-5!"`
+- Update className to use flexbox layout (added `flex items-center gap-1`, `min-w-5!`, `min-h-5!`, `w-fit!`)
+- Add conditional padding `{ "pr-1.5": count > 1 }` when badge is present
+- Render count badge positioned inline with icon and styled with `text-xs -ml-0.5`
+```
+No need to specifically mention new or modified imports. that is considered "noise" in a good git-commit message.
+Also, no need to be overly verbos and mention each added attribute or property and it's value. it's enough to shortly mentioned it was added or modified without specifying from which value to which new value.
+
+**Better Pattern:**
+```
+ComponentName.tsx:
+- Add `data-test-id` attribute to `ComponentName`
+- Style adjustments
+- Add `count` parameter with default value of 1 to InsightIcon
+- Render count badge as `<span>` element only when count is greater than 1
+```
+
+"Style adjustments" encompass all layout-reletaed changes such as classnames or `style` values related to layout/colors or any MUI `sx` prop changes.
+
+**Principle:**
+From a code reviewer's perspective: what do they need to understand the **functional change**? CSS and styling mechanics are lower-level concerns that obscure the actual feature changes.
+
+
+## Semantic Commit Messages (Recommended Approach)
+
+Write commit messages that describe the **cohesive idea** behind changes, not implementation details.
+
+### Think Conceptually, Not Line-by-Line
+
+The goal is to answer: "What does this change accomplish?" not "What code lines changed?"
+
+**Bad (lists implementation details):**
+```
+refactor(SparkInsight): improve component typing and handle undefined data
+
+- Add undefined to insights prop type
+- Apply optional chaining to insight property accesses
+- Add early return guard when insight is undefined
+- Conditionally render dependent components
+- Update return types accordingly
+```
+
+**Good (describes the unified concept):**
+```
+refactor(SparkInsight): handle undefined insights data
+
+Component now gracefully handles cases where insights prop is undefined, applying
+defensive checks throughout the data flow with early return when no data exists.
+```
+
+### When to Use Per-File Format
+
+Only break down by file when **different files solve fundamentally different problems**:
+
+```
+refactor(UI): improve error handling and add loading states
+
+ComponentA.tsx:
+- Add error boundary wrapper for graceful error display
+
+ComponentB.tsx:
+- Add loading spinner during data fetch
+
+utils/errorHandler.ts:
+- Extract common error handling logic for reuse
+```
+
+**NOT** for thematically unified changes (e.g., adding null safety across a component hierarchy).
+
+### Rule of Thumb
+
+**Single semantic message**: If you can describe the commit in one clear sentence without listing files individually, do that.
+
+**Per-file format**: If changes solve distinct problems across different files, break it down.
+
+Use per-file format sparingly—most changes are unified in purpose.
+
+## Follow these instructions (STRICT - NO EXCEPTIONS):
+
+### STEP 1: DETERMINE SCOPE (MANDATORY FIRST STEP)
+
+```bash
+git diff --staged --name-only
+```
+
+**CRITICAL DECISION POINT - Choose ONE path only:**
+
+- **IF OUTPUT IS NOT EMPTY** (staged files exist):
+  - ✅ Use ONLY `git diff --staged` for ALL analysis
+  - ❌ NEVER analyze or mention unstaged files
+  - ❌ NEVER look at working tree changes
+  - ONLY commit the staged files
+
+- **IF OUTPUT IS EMPTY** (no staged files):
+  - ✅ Use ONLY `git diff` for ALL analysis
+  - ✅ Analyze ALL working tree changes
+  - ❌ NEVER use `--staged` flag
+  - ONLY commit all working tree changes
+
+**ABORT if you're unsure which mode applies. Ask the user to clarify.**
+
+### STEP 2: REVIEW CHANGES (APPLY ONLY THE RELEVANT COMMAND)
+
+**IF STAGED FILES EXIST:**
+```bash
+git diff --staged | cat
+```
+
+**IF NO STAGED FILES:**
+```bash
+git diff | cat
+```
+
+**NEVER MIX BOTH COMMANDS. NEVER ANALYZE BOTH STAGED AND UNSTAGED FILES TOGETHER.**
+
+### STEP 3: ANALYZE CHANGES
+
+After reviewing, focus on:
+- Primary purpose (determines type)
+- Scope of changes (ONLY the files you reviewed in Step 2)
+- Breaking changes
+- Security implications
+- Performance impact
+
+### STEP 4: WRITE MESSAGE FOCUSING ON:
+- What changed (in the files you reviewed)
+- Why it changed (if not obvious)
+- Impact of change
+- Avoid implementation details unless crucial
+- If a new component was added, mention its name and the fact it was added
+- If a component was moved or renamed, mention its old name and new name/path
+- If "debug mode" was used, specify for what JSX section or for which purpose it is used for
+- For typescript-related changes in a file, simply write the filename and mention shorty if types were added or improved/modified
+- For function signature changes, explicitly state the old and new parameters
+
+### STEP 5: EXCLUDE FROM COMMIT MESSAGE
+- Code comments or their changes
+- "TODO" comments
+- Individual import changes (unless they were missing, or consolidate related import removals/additions as "and associated imports" when part of code extraction/refactoring)
+
+## Platform-Specific Notes
+
+### Windows Git Bash Users
+When using Git Bash on Windows, paths must use Unix-style format:
+- ✅ **Correct**: `/c/projects/definity-app` (forward slashes, drive letter as /c/)
+- ❌ **Incorrect**: `c:\projects\definity-app` (backslashes, Windows path format)
+
+**Example command for Windows Git Bash:**
+```bash
+cd /c/projects/definity-app && git diff --staged --name-only
+```
+
+### macOS / Linux Users
+Standard Unix paths work as expected:
+```bash
+cd ~/projects/definity-app && git diff --staged --name-only
+```
+
+### Windows PowerShell / CMD Users
+Use native Windows paths:
+```powershell
+cd C:\projects\definity-app; git diff --staged --name-only
+```
+
+If using an IDE terminal (like Cursor's built-in terminal), it typically auto-detects and handles these conversions. If commands fail with "No such file or directory" errors, verify:
+1. You're using the correct path format for your shell
+2. Your shell supports Unix-style paths (Git Bash, WSL) or Windows paths (PowerShell, CMD)
+3. Consider running these commands directly in your IDE's terminal which usually handles path translation

--- a/.cursor/commands/implement-plan.md
+++ b/.cursor/commands/implement-plan.md
@@ -1,0 +1,1 @@
+implement plan and at each step summon a critic which reviews if the work at that stage was done correctly. fix if needed and continue. No need to run any "yarn" commands.

--- a/.cursor/commands/plan-refactor.md
+++ b/.cursor/commands/plan-refactor.md
@@ -1,0 +1,3 @@
+you are a very senior dev. read this file and explore refactoring opportunities.
+Convert your findings into a detailed plan.
+Ask me anything in the proccess which you are uncertain of.

--- a/.cursor/commands/pr-description.md
+++ b/.cursor/commands/pr-description.md
@@ -1,0 +1,112 @@
+# PR Description Generation Rules
+
+## Purpose
+Rules for generating high-quality PR descriptions by analyzing branch changes.
+
+## User Intent: Update vs Print Only
+
+- **If user asks to update** (e.g., "update", "update the pr"): Print the title + description, then run `gh pr edit --title "..." --body "..."` to update the PR. If `gh` is not available or not authenticated, inform the user that [GitHub CLI](https://cli.github.com/) (`gh`) is required for automatic updates—still print the content for manual copy-paste.
+- **If user does NOT ask to update**: Only print the title + description in a code block. Do not run any `gh` commands.
+
+## Key Insights
+
+1. **Information Gathering Is Critical**
+   - Branch names often reveal intent and scope
+   - **Full commit messages are essential** - they contain complete rationale and implementation details, not just subject lines
+   - Component relationships reveal the broader impact of changes
+   - Code search provides deeper context than git commands alone
+
+2. **Structured Organization Matters**
+   - Categorize changes into logical groups
+   - Use nested bullet points for hierarchy
+   - Present information in order of importance
+   - Balance completeness with conciseness
+
+3. **Output Format Is Important**
+   - Always provide markdown in a code block for easy copying
+   - Avoid explanatory text around the description
+   - Use consistent formatting for predictability
+   - Include proper headings and emphasis
+
+4. **Context Matters Most**
+   - Explain not just what changed but why **only when explicitly stated in commit messages**
+   - **Avoid speculative reasoning** - do not guess why changes were made with "for..." explanations unless the commit message clearly states the reason
+   - Connect technical changes to functional outcomes when evident from the code/commits
+   - Highlight relationships between components
+   - Provide the broader purpose of changes to aid reviewers
+
+## Key Steps
+
+1. **Gather Information EFFICIENTLY**
+   - **Use parallel tool calls** - gather all basic information at once:
+     - `git branch --show-current`
+     - `git log --no-merges --format="%H|%s|%b" origin/[base_branch]..HEAD | cat` ("base_branch" default is "main")
+     - `git diff --name-only origin/main..HEAD | cat`
+   - **Trust commit messages first** - they contain the complete rationale from developers who made the changes
+   - **Stop digging when you have enough** - don't over-investigate obvious changes
+   - Only read specific files if the commit messages are unclear or you need to understand complex component relationships
+
+2. **Analyze Changes EFFICIENTLY**
+   - **Start with commit message patterns** - they usually reveal the main categories
+   - **Use the file list strategically** - group files by type/purpose to identify change categories
+   - **Don't investigate version diffs** unless the commit message is unclear about what changed
+   - **Avoid redundant git commands** - if you have the commit message and file list, that's usually sufficient
+
+3. **Format Description**
+   - Use proper markdown inside a code block for easy copying
+   - Start with a clear title reflecting the branch purpose
+   - Group changes in logical categories with nested bullet points
+   - Highlight what was changed and why **only when explicitly stated in commit messages**
+   - **Do not add speculative "for..." explanations** unless the reason is clearly documented in commits
+   - Keep descriptions concise but informative
+   - wrap technical terms, such as file/function/component names, with backticks
+
+4. **Structure Template**
+```markdown
+# [Brief Title Based on Branch Name/Purpose]
+
+## What's Changed
+
+- **[Category of Change]**: [High-level description]
+  - [Specific detail 1]
+  - [Specific detail 2]
+
+- **[Another Category]**:
+  - [Details]
+
+[Optional: Brief concluding statement about overall purpose/impact]
+```
+
+5. **Response Format**
+   - Always wrap the final PR description in a markdown code block for easy copying
+   - Avoid explanatory text around the description itself
+   - Ensure the description stands on its own without requiring additional context
+
+## Common Categories
+- Component Creation/Refactoring
+- UI/UX Enhancements
+- Performance Improvements
+- Architecture/Structure Changes
+- Bug Fixes
+- Documentation Updates
+- Testing Improvements
+
+## Anti-Patterns to Avoid
+
+### Information Gathering Anti-Patterns
+- **Sequential git commands** - Use parallel tool calls for basic information gathering
+- **Over-investigating version changes** - Don't spend multiple commands figuring out exact version diffs unless critical
+- **Ignoring commit messages** - They contain the developer's intent; don't second-guess them
+- **Redundant file analysis** - If commit message + file list tells the story, stop there
+- **Avoid changes which weren't made in this branch** - some changes might have been merged into this branch. ignore such by identifying them using git.
+
+### Analysis Anti-Patterns
+- **Speculative reasoning** - Don't add "for..." explanations unless explicitly stated in commits
+- **Deep-diving obvious changes** - Package updates, lint fixes, and configuration changes are usually straightforward
+- **Perfectionism** - A good PR description doesn't need to explain every technical detail
+
+### Efficiency Guidelines
+- **6 git commands maximum** for most PR descriptions
+- **Parallel > Sequential** - Gather all basic info at once, then analyze
+- **Trust the obvious** - If branch name + commit messages are clear, don't over-analyze
+- **Commit messages are authoritative** - They're written by people who know exactly what they changed and why

--- a/.cursor/commands/review.md
+++ b/.cursor/commands/review.md
@@ -1,1 +1,38 @@
-Act as a senior dev and review. If needed, Ask questions
+Simulate a "Society of Thought" code review — an internal debate among 3 senior developer personas with **opposing dispositions** that make dissent inevitable.
+
+## Personas
+
+1. **The Skeptical Architect** (high conscientiousness, low agreeableness)
+   Domain: system design, abstractions, long-term maintainability.
+   Disposition: Assumes every change introduces hidden complexity. Challenges whether the approach is the right one at all, not just whether the code is correct. Asks "why not do X instead?" before accepting anything.
+
+2. **The Pragmatic Shipper** (high openness, low conscientiousness)
+   Domain: product impact, simplicity, shipping velocity.
+   Disposition: Pushes back on over-engineering and premature abstraction. Champions the simplest solution that works. Challenges the Architect when they propose restructuring that doesn't serve the immediate goal.
+
+3. **The Adversarial Tester** (high neuroticism, low agreeableness)
+   Domain: edge cases, failure modes, security, performance.
+   Disposition: Assumes the code will break. Hunts for unhandled states, race conditions, missing validations, subtle bugs. Distrusts happy-path thinking. Challenges both other personas when they overlook failure scenarios.
+
+## Review Process
+
+**Phase 1 — Independent Analysis**
+Each persona silently reviews the code and prepares their concerns.
+
+**Phase 2 — Adversarial Debate**
+Personas directly challenge each other's findings. When one raises an issue, another must either verify it by finding supporting evidence in the code, or dispute it with a counter-argument. Explore alternatives — don't settle on the first suggestion.
+
+**Phase 3 — Surprise Check**
+Before concluding, each persona must identify one thing that *surprised* them or that they almost overlooked. This forces deeper inspection beyond surface-level patterns.
+
+**Phase 4 — Convergence & Verdict**
+Synthesize the debate into a prioritized list of findings. For each finding, note whether it was **unanimous** or **contested** (and by whom). Contested items are often the most valuable — include the dissenting view.
+
+## Output Format
+
+- **Critical** — must fix before merge
+- **Important** — should fix, creates risk if ignored
+- **Suggestion** — improvement opportunity, not blocking
+- **Positive** — things done well worth calling out (prevents negativity bias)
+
+If anything in the code is ambiguous or lacks sufficient context to review properly, ask targeted questions before proceeding.

--- a/.cursor/commands/save-context.md
+++ b/.cursor/commands/save-context.md
@@ -1,4 +1,4 @@
-Create `{filename}.context.md` documenting session learnings:
+Create `{filename}.context.md` documenting everything you have learned in this chat session:
 
 ## Structure
 1. **Decisions** - choices made + rationale (why > what)
@@ -15,7 +15,9 @@ Create `{filename}.context.md` documenting session learnings:
 - Prefer enums/lists over sentences
 - Include decision trees for conditional logic
 
-## Graph (if complex relationships exist)
+## Graph (if relationships exists between individual aspects)
+- use "mermaid" diagrams only
+
 graph:
   nodes: [A, B, C]
   edges:

--- a/.cursor/commands/suggest-improvements.md
+++ b/.cursor/commands/suggest-improvements.md
@@ -1,0 +1,9 @@
+Act as a Senior Software Engineer. Refactor the code in this file to adhere to "Clean Code" standards while strictly following this priority hierarchy:
+
+Performance: Prioritize execution speed, memory efficiency, and minimizing complexity (O-notation).
+
+Readability: Ensure the logic is intent-revealing and easy to follow.
+
+DRY (Don't Repeat Yourself): Apply abstraction only if it doesn't violate the two priorities above.
+
+Task: Identify refactoring candidates and apply changes that "beautifully craft" the file for a production environment. Use your knowledge of the broader workspace context to ensure architectural consistency.

--- a/.cursor/commands/summarise-as-commit-msg.md
+++ b/.cursor/commands/summarise-as-commit-msg.md
@@ -1,0 +1,7 @@
+Summarise the changes made **in this chat session only** as a git commit message.
+
+- Do NOT run `git diff` or `git status` — you already know what you changed.
+- Base the message solely on the edits you performed and the context of the conversation.
+- Use conventional commit format (e.g. `fix:`, `feat:`, `refactor:`).
+- Output the result in a markdown codebox.
+-

--- a/README.md
+++ b/README.md
@@ -175,7 +175,16 @@ var tagify = new Tagify(...)
 * Original input/textarea element values kept in sync with Tagify
 
 ## Building the project
-Simply run `gulp` in your terminal, from the project's path ([Gulp](https://gulpjs.com) should be installed first).
+Building this repository requires **Node.js 22+** and **pnpm 10+** (see `package.json` `engines`). From the project root, install dependencies and run the build:
+
+```sh
+pnpm install
+pnpm run build
+```
+
+For local development with watch mode, use `pnpm start` (runs Gulp with `--dev`). [Gulp](https://gulpjs.com) is used under the hood; you do not need a global Gulp install if you use the pnpm scripts above.
+
+*(Installing the published package in your app — e.g. `npm i @yaireo/tagify` — is unchanged; the Node/pnpm requirements apply to **contributors** building Tagify from source.)*
 
 Source files are this path: `/src/`
 
@@ -971,6 +980,8 @@ Name                       | Parameters                                         
 `parseMixTags`             | `String`                                                                                | Converts a String argument (`[[foo]]⁠ and [[bar]]⁠ are..`) into HTML with mixed tags & texts
 `getTagElms`               |                                                                                         | Returns a DOM nodes list of all the tags
 `getTagElmByValue`         | `String`                                                                                | Returns a specific tag DOM node by value
+`getTagElmBeforeInput`     |                                                                                         | Returns the tag element immediately before the contenteditable input in the scope (sibling order), or `undefined`. See JSDoc on `getTagElmBeforeInput` in [`src/tagify.js`](https://github.com/yairEO/tagify/blob/master/src/tagify.js).
+`repositionScopeInput`     | `direction`, optional `options`                                                         | Moves the input among tag siblings (`'left'` \| `'right'` \| `'ArrowLeft'` \| `'ArrowRight'`) or after the last tag (`'reset'`). Optional `{ focus?: boolean }`; returns `true` if the input’s DOM position changed. See JSDoc on `repositionScopeInput` in [`src/tagify.js`](https://github.com/yairEO/tagify/blob/master/src/tagify.js).
 `getSetTagData`            | `HTMLElement`, `Object`                                                                 | set/get tag data on a tag element (has`.tagify__tag` class by default)
 `editTag`                  | `HTMLElement`                                                                           | Goes to edit-mode in a specific tag
 `getTagTextNode`           | `HTMLElement`                                                                           | Get the node which has the actual tag's content
@@ -1120,7 +1131,7 @@ userInput                      | <sub>Boolean</sub>           | true            
 focusable                      | <sub>Boolean</sub>           | true                                        | Allow the component as a whole to recieve focus. Implementations of Tagify without an external border should not allow 'focusability' which causes unwanted behaviour. ([use-case example](file:///C:/Users/vsync/projects/tagify/index.html#section-different-look))
 focusInputOnRemove             | <sub>Boolean</sub>           | true                                        | Refocus the input when a tag is removed
 autoComplete.enabled           | <sub>Boolean</sub>           | true                                        | Tries to suggest the input's value while typing (match from whitelist) by adding the rest of term as grayed-out text
-autoComplete.rightKey          | <sub>Boolean</sub>           | false                                       | If `true`, when `→` is pressed, use the suggested value to create a tag, else just auto-completes the input. In mixed-mode this is ignored and treated as "true"
+autoComplete.rightKey          | <sub>Boolean</sub>           | false                                       | If `true`, when `→` is pressed, use the suggested value to create a tag, else just auto-completes the input. In mixed-mode this is ignored and treated as "true". When **`allowCaretBetweenTags`** is `true`, <kbd>→</kbd> first moves the input past the next tag if possible; accepting a suggestion with <kbd>→</kbd> applies when the input does not move. Arrow behavior also interacts with the suggestions dropdown in that mode.
 autoComplete.tabKey            | <sub>Boolean</sub>           | false                                       | If `true`, pressing `tab` key would only auto-complete (if a suggestion is highlighted) but will not convert to a tag (like `rightKey` does) also, unless clicked again (considering the `addTagOn` setting).
 whitelist                      | <sub>Array</sub>             | `[]`                                        | An array of allowed tags (*Strings* or *Objects*). When using *Objects* in the *whitelist* array a `value` property is a must & should be unique. <br/>Also, the *whitelist used for auto-completion when `autoCompletion.enabled` is `true`
 blacklist                      | <sub>Array</sub>             | `[]`                                        | An array of tags which aren't allowed
@@ -1139,7 +1150,8 @@ transformTag                   | <sub>Function</sub>          |                 
 keepInvalidTags                | <sub>Boolean</sub>           | false                                       | If `true`, do not remove tags which did not pass validation
 createInvalidTags              | <sub>Boolean</sub>           | true                                        | If `true`, create invalid-tags. Otherwise, keep the editable input and do not create tags from it
 skipInvalid                    | <sub>Boolean</sub>           | false                                       | If `true`, do not add invalid, temporary, tags before automatically removing them
-backspace                      | <sub>*</sub>                 | true                                        | On pressing backspace key:<br> `true` - remove last tag <br>`edit` - edit last tag<br>`false` - do nothing (useful for outside style)
+backspace                      | <sub>*</sub>                 | true                                        | On pressing backspace key while the input is **empty** (incl. zero-width space):<br> `true` - remove the **tag immediately before the input** <br>`edit` - edit that tag<br>`false` - do nothing (useful for outside style)
+allowCaretBetweenTags          | <sub>Boolean</sub>           | true                                        | When `true` (non-`mix` modes), <kbd>←</kbd> / <kbd>→</kbd> reposition the internal input among tags so new tags can be added between existing ones. No effect in **`mix`** mode. On **blur**, the input returns **after the last tag** unless focus moves into the suggestions dropdown. See also `repositionScopeInput` and `getTagElmBeforeInput` in [Methods](#methods). Full behavior is documented in JSDoc on `Tagify.prototype.repositionScopeInput` in the source.
 originalInputValueFormat       | <sub>Function</sub>          |                                             | If you wish your original input/textarea `value` property format to other than the default (which I recommend keeping) you may use this and make sure it returns a *string*.
 mixMode.*insertAfterTag*       | <sub>Node/String</sub>       | `\u00A0`                                    | `node` or `string` to add after a tag added |
 a11y.*focusableTags*           | <sub>Boolean</sub>           | false                                       | allows tags to get focus, and also to be deleted via <kbd>Backspace</kbd>

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "not op_mini all"
   ],
   "engines": {
-    "npm": ">=9.0.0",
-    "node": ">=16.15.0"
+    "pnpm": ">=10",
+    "node": ">=22"
   },
   "np": {
     "yarn": false,
@@ -74,11 +74,11 @@
     "react-dom": "*"
   },
   "devDependencies": {
-    "@playwright/test": "^1.57.0",
+    "@playwright/test": "^1.59.1",
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/stream": "^3.0.1",
-    "@swc/core": "^1.4.12",
-    "@types/node": "^22.19.7",
+    "@swc/core": "^1.15.21",
+    "@types/node": "^22.19.17",
     "beepbeep": "^1.3.0",
     "gulp": "^5.0.1",
     "gulp-autoprefixer": "^8.0.0",
@@ -106,11 +106,11 @@
     "gulp-watch": "^5.0.1",
     "path": "^0.12.7",
     "rollup": "2.80.0",
-    "rollup-plugin-banner2": "^1.2.3",
-    "rollup-plugin-swc3": "^0.11.0",
+    "rollup-plugin-banner2": "^1.3.1",
+    "rollup-plugin-swc3": "^0.11.2",
     "run-sequence": "^2.2.1",
     "sass": "^1.74.1",
-    "semver": "^7.7.3",
+    "semver": "^7.7.4",
     "vinyl-buffer": "^1.0.1",
     "vinyl-source-stream": "^2.0.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         version: 18.2.0(react@18.2.0)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.57.0
+        specifier: ^1.59.1
+        version: 1.59.1
       '@rollup/plugin-terser':
         specifier: ^0.4.4
         version: 0.4.4(rollup@2.80.0)
@@ -28,11 +28,11 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1(rollup@2.80.0)
       '@swc/core':
-        specifier: ^1.4.12
-        version: 1.4.12
+        specifier: ^1.15.21
+        version: 1.15.21
       '@types/node':
-        specifier: ^22.19.7
-        version: 22.19.7
+        specifier: ^22.19.17
+        version: 22.19.17
       beepbeep:
         specifier: ^1.3.0
         version: 1.3.0
@@ -89,7 +89,7 @@ importers:
         version: 1.0.2
       gulp-swc:
         specifier: ^2.2.0
-        version: 2.2.0(@swc/core@1.4.12)(gulp@5.0.1)
+        version: 2.2.0(@swc/core@1.15.21)(gulp@5.0.1)
       gulp-tag-version:
         specifier: ^1.3.1
         version: 1.3.1
@@ -115,11 +115,11 @@ importers:
         specifier: 2.80.0
         version: 2.80.0
       rollup-plugin-banner2:
-        specifier: ^1.2.3
-        version: 1.2.3
+        specifier: ^1.3.1
+        version: 1.3.1
       rollup-plugin-swc3:
-        specifier: ^0.11.0
-        version: 0.11.0(@swc/core@1.4.12)(rollup@2.80.0)
+        specifier: ^0.11.2
+        version: 0.11.2(@swc/core@1.15.21)(rollup@2.80.0)
       run-sequence:
         specifier: ^2.2.1
         version: 2.2.1
@@ -127,8 +127,8 @@ importers:
         specifier: ^1.74.1
         version: 1.74.1
       semver:
-        specifier: ^7.7.3
-        version: 7.7.3
+        specifier: ^7.7.4
+        version: 7.7.4
       vinyl-buffer:
         specifier: ^1.0.1
         version: 1.0.1
@@ -178,8 +178,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
-  '@playwright/test@1.57.0':
-    resolution: {integrity: sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==}
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -207,71 +207,83 @@ packages:
     peerDependencies:
       rollup: ^2.35.1||^3.0.0||^4.0.0
 
-  '@swc/core-darwin-arm64@1.4.12':
-    resolution: {integrity: sha512-BZUUq91LGJsLI2BQrhYL3yARkcdN4TS3YGNS6aRYUtyeWrGCTKHL90erF2BMU2rEwZLLkOC/U899R4o4oiSHfA==}
+  '@swc/core-darwin-arm64@1.15.21':
+    resolution: {integrity: sha512-SA8SFg9dp0qKRH8goWsax6bptFE2EdmPf2YRAQW9WoHGf3XKM1bX0nd5UdwxmC5hXsBUZAYf7xSciCler6/oyA==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@swc/core-darwin-x64@1.4.12':
-    resolution: {integrity: sha512-Wkk8rq1RwCOgg5ybTlfVtOYXLZATZ+QjgiBNM7pIn03A5/zZicokNTYd8L26/mifly2e74Dz34tlIZBT4aTGDA==}
+  '@swc/core-darwin-x64@1.15.21':
+    resolution: {integrity: sha512-//fOVntgowz9+V90lVsNCtyyrtbHp3jWH6Rch7MXHXbcvbLmbCTmssl5DeedUWLLGiAAW1wksBdqdGYOTjaNLw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [darwin]
 
-  '@swc/core-linux-arm-gnueabihf@1.4.12':
-    resolution: {integrity: sha512-8jb/SN67oTQ5KSThWlKLchhU6xnlAlnmnLCCOKK1xGtFS6vD+By9uL+qeEY2krV98UCRTf68WSmC0SLZhVoz5A==}
+  '@swc/core-linux-arm-gnueabihf@1.15.21':
+    resolution: {integrity: sha512-meNI4Sh6h9h8DvIfEc0l5URabYMSuNvyisLmG6vnoYAS43s8ON3NJR8sDHvdP7NJTrLe0q/x2XCn6yL/BeHcZg==}
     engines: {node: '>=10'}
     cpu: [arm]
     os: [linux]
 
-  '@swc/core-linux-arm64-gnu@1.4.12':
-    resolution: {integrity: sha512-DhW47DQEZKCdSq92v5F03rqdpjRXdDMqxfu4uAlZ9Uo1wJEGvY23e1SNmhji2sVHsZbBjSvoXoBLk0v00nSG8w==}
+  '@swc/core-linux-arm64-gnu@1.15.21':
+    resolution: {integrity: sha512-QrXlNQnHeXqU2EzLlnsPoWEh8/GtNJLvfMiPsDhk+ht6Xv8+vhvZ5YZ/BokNWSIZiWPKLAqR0M7T92YF5tmD3g==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
 
-  '@swc/core-linux-arm64-musl@1.4.12':
-    resolution: {integrity: sha512-PR57pT3TssnCRvdsaKNsxZy9N8rFg9AKA1U7W+LxbZ/7Z7PHc5PjxF0GgZpE/aLmU6xOn5VyQTlzjoamVkt05g==}
+  '@swc/core-linux-arm64-musl@1.15.21':
+    resolution: {integrity: sha512-8/yGCMO333ultDaMQivE5CjO6oXDPeeg1IV4sphojPkb0Pv0i6zvcRIkgp60xDB+UxLr6VgHgt+BBgqS959E9g==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
 
-  '@swc/core-linux-x64-gnu@1.4.12':
-    resolution: {integrity: sha512-HLZIWNHWuFIlH+LEmXr1lBiwGQeCshKOGcqbJyz7xpqTh7m2IPAxPWEhr/qmMTMsjluGxeIsLrcsgreTyXtgNA==}
+  '@swc/core-linux-ppc64-gnu@1.15.21':
+    resolution: {integrity: sha512-ucW0HzPx0s1dgRvcvuLSPSA/2Kk/VYTv9st8qe1Kc22Gu0Q0rH9+6TcBTmMuNIp0Xs4BPr1uBttmbO1wEGI49Q==}
+    engines: {node: '>=10'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@swc/core-linux-s390x-gnu@1.15.21':
+    resolution: {integrity: sha512-ulTnOGc5I7YRObE/9NreAhQg94QkiR5qNhhcUZ1iFAYjzg/JGAi1ch+s/Ixe61pMIr8bfVrF0NOaB0f8wjaAfA==}
+    engines: {node: '>=10'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@swc/core-linux-x64-gnu@1.15.21':
+    resolution: {integrity: sha512-D0RokxtM+cPvSqJIKR6uja4hbD+scI9ezo95mBhfSyLUs9wnPPl26sLp1ZPR/EXRdYm3F3S6RUtVi+8QXhT24Q==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
 
-  '@swc/core-linux-x64-musl@1.4.12':
-    resolution: {integrity: sha512-M5fBAtoOcpz2YQAFtNemrPod5BqmzAJc8pYtT3dVTn1MJllhmLHlphU8BQytvoGr1PHgJL8ZJBlBGdt70LQ7Mw==}
+  '@swc/core-linux-x64-musl@1.15.21':
+    resolution: {integrity: sha512-nER8u7VeRfmU6fMDzl1NQAbbB/G7O2avmvCOwIul1uGkZ2/acbPH+DCL9h5+0yd/coNcxMBTL6NGepIew+7C2w==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
 
-  '@swc/core-win32-arm64-msvc@1.4.12':
-    resolution: {integrity: sha512-K8LjjgZ7VQFtM+eXqjfAJ0z+TKVDng3r59QYn7CL6cyxZI2brLU3lNknZcUFSouZD+gsghZI/Zb8tQjVk7aKDQ==}
+  '@swc/core-win32-arm64-msvc@1.15.21':
+    resolution: {integrity: sha512-+/AgNBnjYugUA8C0Do4YzymgvnGbztv7j8HKSQLvR/DQgZPoXQ2B3PqB2mTtGh/X5DhlJWiqnunN35JUgWcAeQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [win32]
 
-  '@swc/core-win32-ia32-msvc@1.4.12':
-    resolution: {integrity: sha512-hflO5LCxozngoOmiQbDPyvt6ODc5Cu9AwTJP9uH/BSMPdEQ6PCnefuUOJLAKew2q9o+NmDORuJk+vgqQz9Uzpg==}
+  '@swc/core-win32-ia32-msvc@1.15.21':
+    resolution: {integrity: sha512-IkSZj8PX/N4HcaFhMQtzmkV8YSnuNoJ0E6OvMwFiOfejPhiKXvl7CdDsn1f4/emYEIDO3fpgZW9DTaCRMDxaDA==}
     engines: {node: '>=10'}
     cpu: [ia32]
     os: [win32]
 
-  '@swc/core-win32-x64-msvc@1.4.12':
-    resolution: {integrity: sha512-3A4qMtddBDbtprV5edTB/SgJn9L+X5TL7RGgS3eWtEgn/NG8gA80X/scjf1v2MMeOsrcxiYhnemI2gXCKuQN2g==}
+  '@swc/core-win32-x64-msvc@1.15.21':
+    resolution: {integrity: sha512-zUyWso7OOENB6e1N1hNuNn8vbvLsTdKQ5WKLgt/JcBNfJhKy/6jmBmqI3GXk/MyvQKd5SLvP7A0F36p7TeDqvw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [win32]
 
-  '@swc/core@1.4.12':
-    resolution: {integrity: sha512-QljRxTaUajSLB9ui93cZ38/lmThwIw/BPxjn+TphrYN6LPU3vu9/ykjgHtlpmaXDDcngL4K5i396E7iwwEUxYg==}
+  '@swc/core@1.15.21':
+    resolution: {integrity: sha512-fkk7NJcBscrR3/F8jiqlMptRHP650NxqDnspBMrRe5d8xOoCy9MLL5kOBLFXjFLfMo3KQQHhk+/jUULOMlR1uQ==}
     engines: {node: '>=10'}
     peerDependencies:
-      '@swc/helpers': ^0.5.0
+      '@swc/helpers': '>=0.5.17'
     peerDependenciesMeta:
       '@swc/helpers':
         optional: true
@@ -279,8 +291,8 @@ packages:
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
 
-  '@swc/types@0.1.6':
-    resolution: {integrity: sha512-/JLo/l2JsT/LRd80C3HfbmVpxOAJ11FO2RCEslFrgzLltoP9j8XIbsyDcfCt2WWyX+CM96rBoNM+IToAkFOugg==}
+  '@swc/types@0.1.26':
+    resolution: {integrity: sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==}
 
   '@types/estree@1.0.5':
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
@@ -288,8 +300,8 @@ packages:
   '@types/expect@1.20.4':
     resolution: {integrity: sha512-Q5Vn3yjTDyCMV50TB6VRIbQNxSE4OmZR86VSbGaNpfUolm0iePBB4KdEEHmxoY5sT2+2DIvXW0rvMDP2nHZ4Mg==}
 
-  '@types/node@22.19.7':
-    resolution: {integrity: sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==}
+  '@types/node@22.19.17':
+    resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
   '@types/vinyl@2.0.11':
     resolution: {integrity: sha512-vPXzCLmRp74e9LsP8oltnWKTH+jBwt86WgRUb4Pc9Lf3pkMVGyvIo2gm9bODeGfCay2DBB/hAWDuvf07JcK4rw==}
@@ -475,8 +487,9 @@ packages:
     resolution: {integrity: sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==}
     engines: {node: '>=0.10.0'}
 
-  baseline-browser-mapping@2.9.15:
-    resolution: {integrity: sha512-kX8h7K2srmDyYnXRIppo4AH/wYgzWVCs+eKr3RusRSQ5PvRYoEFmR/I0PbdTjKFAoKqp5+kbxnNTFO9jOfSVJg==}
+  baseline-browser-mapping@2.10.14:
+    resolution: {integrity: sha512-fOVLPAsFTsQfuCkvahZkzq6nf8KvGWanlYoTh0SVA0A/PIUxQGU2AOZAoD95n2gFLVDW/jP6sbGLny95nmEuHA==}
+    engines: {node: '>=6.0.0'}
     hasBin: true
 
   beepbeep@1.3.0:
@@ -550,8 +563,8 @@ packages:
     resolution: {integrity: sha512-DLIsRzJVBQu72meAKPkWQOLcujdXT32hwdfnkI1frSiSRMK1MofjKHf+MEx0SB6fjEFXL8fBDv1dKymBlOp4Qw==}
     engines: {node: '>=0.10.0'}
 
-  caniuse-lite@1.0.30001764:
-    resolution: {integrity: sha512-9JGuzl2M+vPL+pz70gtMF9sHdMFbY9FJaQBi186cHKH3pSzDvzoUJUPV6fqiKIMyXbud9ZLg4F3Yza1vJ1+93g==}
+  caniuse-lite@1.0.30001784:
+    resolution: {integrity: sha512-WU346nBTklUV9YfUl60fqRbU5ZqyXlqvo1SgigE1OAXK5bFL8LL9q1K7aap3N739l4BvNqnkm3YrGHiY9sfUQw==}
 
   chalk@0.5.1:
     resolution: {integrity: sha512-bIKA54hP8iZhyDT81TOsJiQvR1gW+ZYSXFaZUAvoD4wCHdbHY2actmpTE4x344ZlFqHbvoxKOaESULTZN2gstg==}
@@ -1807,13 +1820,13 @@ packages:
     resolution: {integrity: sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==}
     engines: {node: '>=0.10.0'}
 
-  playwright-core@1.57.0:
-    resolution: {integrity: sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==}
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.57.0:
-    resolution: {integrity: sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==}
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2010,12 +2023,12 @@ packages:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  rollup-plugin-banner2@1.2.3:
-    resolution: {integrity: sha512-lhpPoDTRZMIvSK1AppGNDIZ4fnQuW4WuENuswSUzvXhTR596zWNOmCaCYoqD15QixnjnG+wT+jauLEK5qGRPZg==}
+  rollup-plugin-banner2@1.3.1:
+    resolution: {integrity: sha512-BUxYj2FbSCxgfyvln6f1AWG1n+b1ZUXXb/LkKpClB12CTIjwDFexWw35V/STz7xT+BLat475I204aRzpxRQwKg==}
     engines: {node: '>=12.13'}
 
-  rollup-plugin-swc3@0.11.0:
-    resolution: {integrity: sha512-luB9Ngb1YieWPpJttKvkmjN3lG5l28SmASLbf2CoScUB2+EImU0bE8wX4EYKEqv5clVulhWRQHQvE+H33X/03g==}
+  rollup-plugin-swc3@0.11.2:
+    resolution: {integrity: sha512-o1ih9B806fV2wBSNk46T0cYfTF2eiiKmYXRpWw3K4j/Cp3tCAt10UCVsTqvUhGP58pcB3/GZcAVl5e7TCSKN6Q==}
     engines: {node: '>=12'}
     peerDependencies:
       '@swc/core': '>=1.2.165'
@@ -2067,8 +2080,8 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
-  semver@7.7.3:
-    resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -2534,9 +2547,9 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
 
-  '@playwright/test@1.57.0':
+  '@playwright/test@1.59.1':
     dependencies:
-      playwright: 1.57.0
+      playwright: 1.59.1
 
   '@rollup/plugin-terser@0.4.4(rollup@2.80.0)':
     dependencies:
@@ -2558,55 +2571,63 @@ snapshots:
     dependencies:
       rollup: 2.80.0
 
-  '@swc/core-darwin-arm64@1.4.12':
+  '@swc/core-darwin-arm64@1.15.21':
     optional: true
 
-  '@swc/core-darwin-x64@1.4.12':
+  '@swc/core-darwin-x64@1.15.21':
     optional: true
 
-  '@swc/core-linux-arm-gnueabihf@1.4.12':
+  '@swc/core-linux-arm-gnueabihf@1.15.21':
     optional: true
 
-  '@swc/core-linux-arm64-gnu@1.4.12':
+  '@swc/core-linux-arm64-gnu@1.15.21':
     optional: true
 
-  '@swc/core-linux-arm64-musl@1.4.12':
+  '@swc/core-linux-arm64-musl@1.15.21':
     optional: true
 
-  '@swc/core-linux-x64-gnu@1.4.12':
+  '@swc/core-linux-ppc64-gnu@1.15.21':
     optional: true
 
-  '@swc/core-linux-x64-musl@1.4.12':
+  '@swc/core-linux-s390x-gnu@1.15.21':
     optional: true
 
-  '@swc/core-win32-arm64-msvc@1.4.12':
+  '@swc/core-linux-x64-gnu@1.15.21':
     optional: true
 
-  '@swc/core-win32-ia32-msvc@1.4.12':
+  '@swc/core-linux-x64-musl@1.15.21':
     optional: true
 
-  '@swc/core-win32-x64-msvc@1.4.12':
+  '@swc/core-win32-arm64-msvc@1.15.21':
     optional: true
 
-  '@swc/core@1.4.12':
+  '@swc/core-win32-ia32-msvc@1.15.21':
+    optional: true
+
+  '@swc/core-win32-x64-msvc@1.15.21':
+    optional: true
+
+  '@swc/core@1.15.21':
     dependencies:
       '@swc/counter': 0.1.3
-      '@swc/types': 0.1.6
+      '@swc/types': 0.1.26
     optionalDependencies:
-      '@swc/core-darwin-arm64': 1.4.12
-      '@swc/core-darwin-x64': 1.4.12
-      '@swc/core-linux-arm-gnueabihf': 1.4.12
-      '@swc/core-linux-arm64-gnu': 1.4.12
-      '@swc/core-linux-arm64-musl': 1.4.12
-      '@swc/core-linux-x64-gnu': 1.4.12
-      '@swc/core-linux-x64-musl': 1.4.12
-      '@swc/core-win32-arm64-msvc': 1.4.12
-      '@swc/core-win32-ia32-msvc': 1.4.12
-      '@swc/core-win32-x64-msvc': 1.4.12
+      '@swc/core-darwin-arm64': 1.15.21
+      '@swc/core-darwin-x64': 1.15.21
+      '@swc/core-linux-arm-gnueabihf': 1.15.21
+      '@swc/core-linux-arm64-gnu': 1.15.21
+      '@swc/core-linux-arm64-musl': 1.15.21
+      '@swc/core-linux-ppc64-gnu': 1.15.21
+      '@swc/core-linux-s390x-gnu': 1.15.21
+      '@swc/core-linux-x64-gnu': 1.15.21
+      '@swc/core-linux-x64-musl': 1.15.21
+      '@swc/core-win32-arm64-msvc': 1.15.21
+      '@swc/core-win32-ia32-msvc': 1.15.21
+      '@swc/core-win32-x64-msvc': 1.15.21
 
   '@swc/counter@0.1.3': {}
 
-  '@swc/types@0.1.6':
+  '@swc/types@0.1.26':
     dependencies:
       '@swc/counter': 0.1.3
 
@@ -2614,14 +2635,14 @@ snapshots:
 
   '@types/expect@1.20.4': {}
 
-  '@types/node@22.19.7':
+  '@types/node@22.19.17':
     dependencies:
       undici-types: 6.21.0
 
   '@types/vinyl@2.0.11':
     dependencies:
       '@types/expect': 1.20.4
-      '@types/node': 22.19.7
+      '@types/node': 22.19.17
 
   a-sync-waterfall@1.0.1: {}
 
@@ -2740,7 +2761,7 @@ snapshots:
   autoprefixer@10.4.23(postcss@8.5.6):
     dependencies:
       browserslist: 4.28.1
-      caniuse-lite: 1.0.30001764
+      caniuse-lite: 1.0.30001784
       fraction.js: 5.3.4
       picocolors: 1.1.1
       postcss: 8.5.6
@@ -2769,7 +2790,7 @@ snapshots:
       mixin-deep: 1.3.2
       pascalcase: 0.1.1
 
-  baseline-browser-mapping@2.9.15: {}
+  baseline-browser-mapping@2.10.14: {}
 
   beepbeep@1.3.0: {}
 
@@ -2829,8 +2850,8 @@ snapshots:
 
   browserslist@4.28.1:
     dependencies:
-      baseline-browser-mapping: 2.9.15
-      caniuse-lite: 1.0.30001764
+      baseline-browser-mapping: 2.10.14
+      caniuse-lite: 1.0.30001784
       electron-to-chromium: 1.5.267
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
@@ -2865,7 +2886,7 @@ snapshots:
 
   camelcase@2.1.1: {}
 
-  caniuse-lite@1.0.30001764: {}
+  caniuse-lite@1.0.30001784: {}
 
   chalk@0.5.1:
     dependencies:
@@ -3547,7 +3568,7 @@ snapshots:
 
   gulp-replace@1.1.4:
     dependencies:
-      '@types/node': 22.19.7
+      '@types/node': 22.19.17
       '@types/vinyl': 2.0.11
       istextorbinary: 3.3.0
       replacestream: 4.0.3
@@ -3582,9 +3603,9 @@ snapshots:
     dependencies:
       plexer: 1.0.1
 
-  gulp-swc@2.2.0(@swc/core@1.4.12)(gulp@5.0.1):
+  gulp-swc@2.2.0(@swc/core@1.15.21)(gulp@5.0.1):
     dependencies:
-      '@swc/core': 1.4.12
+      '@swc/core': 1.15.21
       gulp: 5.0.1
       plugin-error: 2.0.1
       source-map: 0.7.6
@@ -4335,11 +4356,11 @@ snapshots:
 
   pinkie@2.0.4: {}
 
-  playwright-core@1.57.0: {}
+  playwright-core@1.59.1: {}
 
-  playwright@1.57.0:
+  playwright@1.59.1:
     dependencies:
-      playwright-core: 1.57.0
+      playwright-core: 1.59.1
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -4547,15 +4568,15 @@ snapshots:
 
   reusify@1.0.4: {}
 
-  rollup-plugin-banner2@1.2.3:
+  rollup-plugin-banner2@1.3.1:
     dependencies:
       magic-string: 0.25.9
 
-  rollup-plugin-swc3@0.11.0(@swc/core@1.4.12)(rollup@2.80.0):
+  rollup-plugin-swc3@0.11.2(@swc/core@1.15.21)(rollup@2.80.0):
     dependencies:
       '@fastify/deepmerge': 1.3.0
       '@rollup/pluginutils': 5.1.0(rollup@2.80.0)
-      '@swc/core': 1.4.12
+      '@swc/core': 1.15.21
       get-tsconfig: 4.7.3
       rollup: 2.80.0
       rollup-preserve-directives: 1.1.1(rollup@2.80.0)
@@ -4604,7 +4625,7 @@ snapshots:
   semver@6.3.1:
     optional: true
 
-  semver@7.7.3: {}
+  semver@7.7.4: {}
 
   serialize-javascript@6.0.2:
     dependencies:

--- a/src/parts/defaults.js
+++ b/src/parts/defaults.js
@@ -19,9 +19,9 @@ export default {
     mixTagsAllowedAfter : /,|\.|\:|\s/,   // RegEx - Define conditions in which mix-tags content allows a tag to be added after
     mixTagsInterpolator : ['[[', ']]'],   // Interpolation for mix mode. Everything between these will become a tag, if is a valid Object
     backspace           : true,           // false / true / "edit"
+    allowCaretBetweenTags : true,         // if true, allows for caret between tags
     skipInvalid         : false,          // If `true`, do not add invalid, temporary, tags before automatically removing them
     pasteAsTags         : true,           // automatically converts pasted text into tags. if "false", allows for further text editing
-
     editTags            : {
         clicks      : 2,                  // clicks to enter "edit-mode": 1 for single click. any other value is considered as double-click
         keepInvalid : true                // keeps invalid edits as-is until `esc` is pressed while in focus

--- a/src/parts/events.js
+++ b/src/parts/events.js
@@ -504,19 +504,22 @@ export default {
                     var isManualDropdown = _s.dropdown.position == 'manual';
 
                     switch( e.key ){
-                        case 'Backspace' :
+                        case 'Backspace' : {
+                            var tagBefore = this.getTagElmBeforeInput();
+
                             if( _s.mode == 'select' && _s.enforceWhitelist && this.value.length)
-                                this.removeTags()
+                                tagBefore && this.removeTags(tagBefore)
 
                             else if( !this.state.dropdown.visible || _s.dropdown.position == 'manual' ){
                                 if( e.target.textContent == "" || s.charCodeAt(0) == 8203 ){  // 8203: ZERO WIDTH SPACE unicode
                                     if( _s.backspace === true )
-                                        this.removeTags()
+                                        tagBefore && this.removeTags(tagBefore)
                                     else if( _s.backspace == 'edit' )
-                                        setTimeout(this.editTag.bind(this), 0) // timeout reason: when edited tag gets focused and the caret is placed at the end, the last character gets deletec (because of backspace)
+                                        tagBefore && setTimeout(() => this.editTag(tagBefore), 0) // timeout reason: when edited tag gets focused and the caret is placed at the end, the last character gets deletec (because of backspace)
                                 }
                             }
                             break;
+                        }
 
                         case 'Esc' :
                         case 'Escape' :

--- a/src/parts/events.js
+++ b/src/parts/events.js
@@ -188,6 +188,13 @@ export default {
                 shouldAddTags;
 
             if( lostFocus ){
+                // normalize input to end of scope; skip while focus moves into the portaled dropdown (avoid layout jump mid-selection)
+                if( _s.mode != 'mix' ){
+                    var focusWentToDropdown = e.relatedTarget && this.DOM.dropdown?.contains(e.relatedTarget);
+                    if( !focusWentToDropdown )
+                        this.repositionScopeInput('reset', { focus: false })
+                }
+
                 if( e.relatedTarget === this.DOM.scope ){
                     this.dropdown.hide()
                     this.DOM.input.focus()
@@ -524,13 +531,23 @@ export default {
                                 this.dropdown.show()
                             break;
 
+                        case 'ArrowLeft' : {
+                            if( this.repositionScopeInput('left') )
+                                e.preventDefault();
+                            break;
+                        }
+
                         case 'ArrowRight' : {
+                            if( this.repositionScopeInput('right') ){
+                                e.preventDefault();
+                                break;
+                            }
                             let tagData = this.state.inputSuggestion || this.state.ddItemData
                             if( tagData && _s.autoComplete.rightKey ){
                                 this.addTags([tagData], true)
                                 return;
                             }
-                            break
+                            break;
                         }
 
                         case 'Tab' : {

--- a/src/parts/suggestions.js
+++ b/src/parts/suggestions.js
@@ -111,8 +111,9 @@ export default {
 
                             case 'ArrowRight' :
                                 // do not continue if the left arrow key was pressed while typing, because assuming the user wants to bypass any of the below logic and edit the content without intervention.
-                                // also do not procceed if a tag should be created when the setting `autoComplete.rightKey` is set to `true`
-                                if( this.state.actions.ArrowLeft || _s.autoComplete.rightKey )
+                                // also do not procceed if a tag should be created when the setting `autoComplete.rightKey` is set to `true`.
+                                // also do not procceed if the caret is between tags and the user is trying to move the caret to the right
+                                if( this.state.actions.ArrowLeft || _s.autoComplete.rightKey || _s.allowCaretBetweenTags )
                                     return
                             case 'Tab' : {
                                 let shouldAutocompleteOnKey = !_s.autoComplete.rightKey || !_s.autoComplete.tabKey

--- a/src/tagify.js
+++ b/src/tagify.js
@@ -905,6 +905,16 @@ Tagify.prototype = {
     },
 
     /**
+     * Tag element immediately before {@link Tagify#DOM.input} in the scope (sibling order).
+     * Used for Backspace and for ArrowLeft in {@link Tagify#repositionScopeInput} when the input may sit between tags.
+     * @returns {HTMLElement|undefined}
+     */
+    getTagElmBeforeInput(){
+        var prev = this.DOM.input && this.DOM.input.previousElementSibling;
+        return isNodeTag.call(this, prev) ? prev : undefined;
+    },
+
+    /**
      * Searches if any tag with a certain value already exis
      * @param  {String/Object} value [text value / tag data object]
      * @param  {Boolean} caseSensitive
@@ -1799,10 +1809,10 @@ Tagify.prototype = {
             return false;
 
         if( direction === 'left' || direction === 'ArrowLeft' ){
-            var previousSibling = input.previousElementSibling;
-            if( !isNodeTag.call(this, previousSibling) )
+            var tagBefore = this.getTagElmBeforeInput();
+            if( !tagBefore )
                 return false;
-            scope.insertBefore(input, previousSibling);
+            scope.insertBefore(input, tagBefore);
             focus && input.focus();
             return true;
         }

--- a/src/tagify.js
+++ b/src/tagify.js
@@ -1758,6 +1758,68 @@ Tagify.prototype = {
     },
 
     /**
+     * Moves the contenteditable input among tag siblings (when `allowCaretBetweenTags`), or places it immediately
+     * after the last tag (`reset`). No-op in `mix` mode, wrong parent, `reset` with no tags or input already after
+     * last tag, or when `left`/`right` but `allowCaretBetweenTags` is off.
+     * @param {'left'|'right'|'ArrowLeft'|'ArrowRight'|'reset'} direction
+     * @param {{focus?: boolean}} [options] - Whether to call `focus()` on the input after a successful move. Defaults to `true` for `left`/`right`, `false` for `reset` (e.g. blur should not steal focus back).
+     * @returns {boolean} `true` if the input’s position in the DOM changed
+     */
+    repositionScopeInput(direction, options = {}){
+        var input = this.DOM.input,
+            scope = this.DOM.scope,
+            _s = this.settings,
+            parent = input && input.parentNode,
+            isReset = direction === 'reset',
+            focus = options.focus !== undefined ? options.focus : !isReset;
+
+        // mix-mode layout is not “tags + input siblings”; moving the input would corrupt the DOM
+        if( _s.mode == 'mix' )
+            return false;
+
+        if( !input || !scope || parent != scope )
+            return false;
+
+        if( isReset ){
+            var tagElms = this.getTagElms(),
+                lastTag = tagElms[tagElms.length - 1];
+
+            if( !lastTag )
+                return false;
+
+            if( lastTag.nextElementSibling === input )
+                return false;
+
+            lastTag.after(input);
+            focus && input.focus();
+            return true;
+        }
+
+        if( !_s.allowCaretBetweenTags )
+            return false;
+
+        if( direction === 'left' || direction === 'ArrowLeft' ){
+            var previousSibling = input.previousElementSibling;
+            if( !isNodeTag.call(this, previousSibling) )
+                return false;
+            scope.insertBefore(input, previousSibling);
+            focus && input.focus();
+            return true;
+        }
+
+        if( direction === 'right' || direction === 'ArrowRight' ){
+            var nextSibling = input.nextElementSibling;
+            if( !isNodeTag.call(this, nextSibling) )
+                return false;
+            nextSibling.after(input);
+            focus && input.focus();
+            return true;
+        }
+
+        return false;
+    },
+
+    /**
      * creates a DOM tag element and injects it into the component (this.DOM.scope)
      * @param  {Object}  tagData [text value & properties for the created tag]
      * @param  {Object}  extraData [properties which are for the HTML template only]

--- a/src/tagify.scss
+++ b/src/tagify.scss
@@ -229,6 +229,11 @@
         cursor       : default;
         transition   : .13s ease-out;
 
+        // needed when "allowCaretBetweenTags" an the input has been moved (by the user) so it's not the last element
+        &:last-child {
+            margin-right: $tagMargin;
+        }
+
         > div{  // :not([contenteditable])
             display        : flex;
             flex           : 1;
@@ -436,7 +441,7 @@
         margin: $tagMargin;
         padding: var(--tag-pad);
         line-height: normal;
-        min-width: $placeholder-width;
+        min-width: fit-content;
         min-height: 1.5lh;
         position: relative;
         white-space: pre-wrap; // #160 Line break (\n) as delimeter
@@ -444,47 +449,53 @@
         box-sizing: inherit;
         overflow: hidden;
 
+        &:focus{
+            outline:none;
+        }
+
+        &:last-child {
+            min-width: $placeholder-width;
+
+            &:focus{
+                &::before{
+                    @include placeholder(false);
+
+                    /* ALL MS BROWSERS: hide placeholder (on focus) otherwise the caret is placed after it, which is weird */
+                    /* IE Edge 12+ CSS styles go here */
+                    @supports ( -ms-ime-align:auto ) {
+                        display: none;
+                    }
+                }
+
+                &:empty{
+                    &::before{
+                        @include placeholder(true);
+
+                        // Seems to be fixed! no need for the below hack
+                        // @include firefox {
+                        //     // remove ":after" pseudo element: https://bugzilla.mozilla.org/show_bug.cgi?id=904846#c45
+                        //     content: unset;
+                        //     // display:inline-block;
+                        // }
+
+                        color: $placeholder-color-focus;
+                        color: var(--placeholder-color-focus);
+                    }
+
+                     &::after{
+                        @include firefox {
+                            display: none;
+                        }
+                    }
+                }
+            }
+        }
+
         &:empty{
             @include firefox {
               // clicking twice on the input (not fast) disallows typing (bug) only when the input has "display:flex".
               // disabled the below rule for the above reason:
               //  display: flex; // https://bugzilla.mozilla.org/show_bug.cgi?id=904846#c45
-            }
-        }
-
-        &:focus{
-            outline:none;
-
-            &::before{
-                @include placeholder(false);
-
-                /* ALL MS BROWSERS: hide placeholder (on focus) otherwise the caret is placed after it, which is weird */
-                /* IE Edge 12+ CSS styles go here */
-                @supports ( -ms-ime-align:auto ) {
-                    display: none;
-                }
-            }
-
-            &:empty{
-                &::before{
-                    @include placeholder(true);
-
-                    // Seems to be fixed! no need for the below hack
-                    // @include firefox {
-                    //     // remove ":after" pseudo element: https://bugzilla.mozilla.org/show_bug.cgi?id=904846#c45
-                    //     content: unset;
-                    //     // display:inline-block;
-                    // }
-
-                    color: $placeholder-color-focus;
-                    color: var(--placeholder-color-focus);
-                }
-
-                 &::after{
-                    @include firefox {
-                        display: none;
-                    }
-                }
             }
         }
 


### PR DESCRIPTION


- **Caret between tags (#1489)**:
  - Reposition the scope input before or after tags so new tags can be inserted between existing ones (`src/tagify.js`, `src/parts/events.js`, `src/tagify.scss`, `src/parts/suggestions.js`).
  - New setting `allowCaretBetweenTags` in `src/parts/defaults.js`.

- **Backspace (#1489)**:
  - `Backspace` handling treats the input as possibly located between tags; removes the tag immediately before the input instead of always removing the last tag (`src/parts/events.js`).

- **Documentation (`README.md`)**:
  - Documents `allowCaretBetweenTags`, backspace behavior, `rightKey` interaction, `getTagElmBeforeInput`, and `repositionScopeInput`.
  - Documents build expectations: Node 22+, pnpm 10+, and `pnpm` scripts; notes consumer `npm install` is unchanged.

- **Build / tooling**:
  - `package.json`: `engines` set to Node `>=22` and pnpm `>=10`; bumps `@playwright/test`, `@swc/core`, `@types/node`, `rollup-plugin-banner2`, `rollup-plugin-swc3`, and `semver` (`pnpm-lock.yaml`).

- **Cursor IDE**:
  - Adds command markdown files under `.cursor/commands/` (e.g. `pr-description.md`, `review.md`, and others).
  
---

Fixes #1489