### PR TITLE
fix: guard placeCaretAfterNode against empty Selection

### DIFF
--- a/src/parts/helpers.js
+++ b/src/parts/helpers.js
@@ -298,17 +298,14 @@ export function getSetTagData(tagElm, data, override){
 export function placeCaretAfterNode( node ){
     if( !node || !node.parentNode ) return
 
-    var nextSibling = node,
-        sel = window.getSelection(),
-        range = sel.getRangeAt(0);
+    var sel = window.getSelection()
+    if( !sel || !sel.rangeCount ) return
 
-    if (sel.rangeCount) {
-        range.setStartAfter(nextSibling);
-        range.collapse(true)
-        // range.setEndBefore(nextSibling || node);
-        sel.removeAllRanges();
-        sel.addRange(range);
-    }
+    var range = sel.getRangeAt(0)
+    range.setStartAfter(node)
+    range.collapse(true)
+    sel.removeAllRanges()
+    sel.addRange(range)
 }
 
 /**


### PR DESCRIPTION
### Problem

`placeCaretAfterNode` in `src/parts/helpers.js` calls `sel.getRangeAt(0)` before checking `sel.rangeCount`:

```js
var sel   = window.getSelection(),
    range = sel.getRangeAt(0);   // throws IndexSizeError when rangeCount === 0

if (sel.rangeCount) { ... }      // guard runs too late
```